### PR TITLE
Improve output tests

### DIFF
--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -323,9 +323,6 @@ class CorrScope:
                             end_frame = frame + 1
                             break
 
-            if self.raise_on_teardown:
-                raise self.raise_on_teardown
-
         if PRINT_TIMESTAMP:
             # noinspection PyUnboundLocalVariable
             dtime_sec = time.perf_counter() - begin
@@ -338,5 +335,3 @@ class CorrScope:
                 msec_per_frame = float("inf")
 
             print(f"{frame_per_sec:.1f} FPS, {msec_per_frame:.2f} ms/frame")
-
-    raise_on_teardown: Optional[Exception] = None

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,11 @@
 [tool:pytest]
 testpaths = tests
-xfail_strict=true
 addopts = --tb=native
+xfail_strict=true
+
+;By default, pytest searches for tests within classes named Test*.
+;Turn that off.
+python_classes =
 
 [coverage:run]
 branch = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ Integration tests found in:
 import os
 import subprocess
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import pytest
 
@@ -23,18 +23,42 @@ os.chdir(Path(__file__).parent.parent)
 
 @pytest.fixture
 def Popen(mocker: "pytest_mock.MockFixture"):
+    """
+    - This fixture function is called Popen.
+        - pytest names our yield-value Popen too.
+    - The yielded Popen imitates `class Popen`, but is actually a MagicMock instance.
+        - We can't make Popen a class, because a test uses `Popen.call_args`.
+    - To "add class-methods" to Popen, I create a `class MockPopen`
+      and give its classmethods to Popen.
+    """
     real_Popen = subprocess.Popen
 
-    def popen_factory(*args, **kwargs):
-        popen = mocker.create_autospec(real_Popen)
+    class MockPopen(real_Popen):
+        exception_on_write: Optional[Exception] = None
 
-        popen.stdin = mocker.mock_open()(os.devnull, "wb")
-        popen.stdout = mocker.mock_open()(os.devnull, "rb")
-        assert popen.stdin != popen.stdout
+        @classmethod
+        def set_exception(cls, exc: Exception):
+            cls.exception_on_write = exc
 
-        popen.wait.return_value = 0
-        return popen
+        @classmethod
+        def __new__(cls, *args, **kwargs):
+            popen = mocker.create_autospec(real_Popen)
+
+            popen.stdin = mocker.mock_open()(os.devnull, "wb")
+            popen.stdout = mocker.mock_open()(os.devnull, "rb")
+            assert popen.stdin != popen.stdout
+
+            if cls.exception_on_write is not None:
+                popen.stdin.write.side_effect = cls.exception_on_write
+
+            popen.wait.return_value = 0
+            return popen
+
+    # Popen acts exactly the same as MockPopen
+    # when calling classmethods or creating instances.
+    # But Popen is a MagicMock, and captures Popen() call arguments.
 
     Popen = mocker.patch.object(subprocess, "Popen", autospec=True)
-    Popen.side_effect = popen_factory
+    Popen.set_exception = MockPopen.set_exception
+    Popen.side_effect = MockPopen.__new__
     yield Popen


### PR DESCRIPTION
- Remove CorrScope.raise_on_teardown
- Reimplement Popen mock using a class, deduplicate code
- Enable `test_corr_terminate_works` and make it useful

Extracted from failed #282.