### PR TITLE
Enable chroma subsampling by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.6.2 (unreleased)
 
-...
+### Major Changes
+
+- Enable chroma subsampling by default (may affect saved projects) (#331)
 
 ## 0.6.1
 

--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -220,7 +220,7 @@ class FFmpegOutputConfig(IOutputConfig):
     path: Optional[str]
     args: str = ""
 
-    video_template: str = "-c:v libx264 -crf 18 -preset superfast -movflags faststart"
+    video_template: str = "-c:v libx264 -crf 18 -preset superfast -pix_fmt yuv420p -movflags faststart"
     audio_template: str = "-c:a aac -b:a 384k"
 
 


### PR DESCRIPTION
Corrscope previously used yuv444p (full-resolution color, no chroma subsampling). This results in better quality color, but is unplayable in Windows 10 Videos, Android, and many browsers.

This makes corrscope default to yuv420p (half-resolution color), which is already what Youtube transcodes yuv444p videos to.

This may affect previously saved projects if they don't override `video_template`. But most people don't save previous projects.