### PR TITLE
Switch to static ffmepg 4.2.2 to reduce user error and avoid broken ffmpeg builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changelog
 
 - Add menu items linking to config folder and Github repository (#343)
+- Switch to static ffmepg 4.2.2 to reduce user error and avoid broken ffmpeg builds (#332)
 
 ## 0.6.1
 

--- a/corrscope/settings/paths.py
+++ b/corrscope/settings/paths.py
@@ -33,11 +33,13 @@ prepend(os.environ, ["PATH"], PATH_dir + os.pathsep)
 
 
 def get_ffmpeg_url() -> str:
+    linking = "static"
+
     # is_python_64 = sys.maxsize > 2 ** 32
     is_os_64 = platform.machine().endswith("64")
 
     def url(os_ver: str) -> str:
-        return f"https://ffmpeg.zeranoe.com/builds/{os_ver}/shared/ffmpeg-latest-{os_ver}-shared.zip"
+        return f"https://ffmpeg.zeranoe.com/builds/{os_ver}/{linking}/ffmpeg-4.2.2-{os_ver}-{linking}.zip"
 
     if sys.platform == "win32" and is_os_64:
         return url("win64")


### PR DESCRIPTION
Previously we linked to shared-dll ffmpeg builds. When downloading the shared builds, some users fail to extract the DLLs, causing ffmpeg to not work. Static has a larger filesize, but is less likely to confuse users.

Previously, we linked to the latest ffmpeg dev build. I'm unsure if ffmpeg dev builds are unstable or may have bugs varying from version to version. And there is no URL on zeranoe's website to get the latest release build. So instead hard-code/pin the current latest release, and update it from time to time.

- [x] test ffmpeg 4.2.2 to ensure no egregious issues
- [x] test new URL
- [x] why is ffmpeg static bigger than before?
    - https://ffmpeg.zeranoe.com/builds/ ffmpeg 4.0

Fixes #327.