### PR TITLE
Change wave color based on pitch (synesthesia/chromesthesia)

### DIFF
--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -41,6 +41,7 @@ class ChannelConfig(DumpableAttrs):
     render_stereo: Optional[Flatten] = None
 
     line_color: Optional[str] = None
+    color_by_pitch: Optional[bool] = None
 
     # region Legacy Fields
     trigger_width_ratio = Alias("trigger_width")

--- a/corrscope/generate/__init__.py
+++ b/corrscope/generate/__init__.py
@@ -1,0 +1,76 @@
+from typing import List
+
+import attr
+import matplotlib as mpl
+import matplotlib.colors
+import numpy as np
+
+TWOPI = 2 * np.pi
+
+
+@attr.dataclass
+class Palette:
+    unclipped: np.ndarray
+    clipped: List[str]
+
+
+def gen_circular_palette() -> Palette:
+    """Return a palette of 12 *distinct* colors in #rrggbb format.
+    The last color is *not* the same as the first.
+    """
+    # Based on https://youtu.be/xAoljeRJ3lU?t=887
+    N = 12
+
+    VALUE = 85
+    SATURATION = 30
+
+    # Phase of color, so red is 0
+    PHI = 0.2
+    SIGN = -1
+
+    # constant lightness
+    Jp = VALUE * np.ones(N)
+
+    # constant saturation, varying hue
+    t = SIGN * np.linspace(0, 1, N, endpoint=False) + PHI
+
+    ap = SATURATION * np.sin(TWOPI * t)
+    bp = SATURATION * np.cos(TWOPI * t)
+
+    # [N][(Jp, ap, bp) real
+    Jp_ap_bp = np.column_stack((Jp, ap, bp))
+
+    from colorspacious import cspace_convert
+
+    rgb_raw = cspace_convert(Jp_ap_bp, "CAM02-UCS", "sRGB1")
+
+    rgb = np.clip(rgb_raw, 0, None)
+    rgb_max = np.max(rgb, axis=1).reshape(-1, 1)
+    rgb /= rgb_max
+    assert ((0 <= rgb) * (rgb <= 1)).all()
+
+    print(f"Peak overflow = {np.max(rgb_max - 1)}")
+    print(f"Peak underflow = {np.min(rgb_raw - rgb)}")
+
+    rgb = [mpl.colors.to_hex(c) for c in rgb]
+    print(repr(rgb))
+    return Palette(rgb_raw, rgb)
+
+
+if False:
+    spectral_colors = gen_circular_palette().clipped
+else:
+    spectral_colors = [
+        "#ff8189",
+        "#ff9155",
+        "#ffba37",
+        "#f7ff52",
+        "#95ff85",
+        "#16ffc1",
+        "#00ffff",
+        "#4dccff",
+        "#86acff",
+        "#b599ff",
+        "#ed96ff",
+        "#ff87ca",
+    ]

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -970,6 +970,8 @@ class ConfigModel(PresentationModel):
 @attr.dataclass
 class Column:
     key: str
+
+    # fn(str) -> T. If ValueError is thrown, replaced by `default`.
     cls: Union[type, Callable[[str], Any]]
 
     # `default` is written into config,
@@ -990,6 +992,26 @@ def plus_minus_one(value: str) -> int:
 
 
 nope = qc.QVariant()
+
+
+def parse_bool_maybe(s: str) -> Optional[bool]:
+    """Does not throw. But could legally throw ValueError."""
+
+    if not s:
+        return None
+
+    # len(s) >= 1
+    try:
+        return bool(int(s))
+    except ValueError:
+        pass
+
+    s = s.lower()
+    if s[0] in ["t", "y"]:
+        return True
+    if s[0] in ["f", "n"]:
+        return False
+    return None
 
 
 class ChannelModel(qc.QAbstractTableModel):
@@ -1030,6 +1052,7 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("label", str, "", "Label"),
         Column("amplification", float, None, "Amplification\n(override)"),
         Column("line_color", str, None, "Line Color"),
+        Column("color_by_pitch", parse_bool_maybe, None, "Color Lines\nBy Pitch"),
         Column("render_stereo", str, None, "Render Stereo\nDownmix"),
         Column("trigger_width", int, None, "Trigger Width ×"),
         Column("render_width", int, None, "Render Width ×"),

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -167,6 +167,13 @@ class MainWindow(QWidget):
                     self.render__line_width.setMinimum(0.5)
                     self.render__line_width.setSingleStep(0.5)
 
+                with add_row(
+                    s, BoundCheckBox, Both
+                ) as self.render__global_color_by_pitch:
+                    self.render__global_color_by_pitch.setText(
+                        tr("Color Lines By Pitch")
+                    )
+
                 with add_row(s, "", OptionalColorWidget) as self.render__grid_color:
                     pass
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -160,6 +160,10 @@ class RendererConfig(
     bg_color: str = "#000000"
     init_line_color: str = default_color()
 
+    @property
+    def global_line_color(self) -> str:
+        return self.init_line_color
+
     grid_color: Optional[str] = None
     stereo_grid_opacity: float = 0.25
 
@@ -177,7 +181,7 @@ class RendererConfig(
 
     @property
     def get_label_color(self):
-        return coalesce(self.label_color_override, self.init_line_color)
+        return coalesce(self.label_color_override, self.global_line_color)
 
     antialiasing: bool = True
 
@@ -289,7 +293,7 @@ class _RendererBackend(ABC):
             line_colors = [None] * self.nplots
 
         self._line_params = [
-            LineParam(color=coalesce(color, cfg.init_line_color))
+            LineParam(color=coalesce(color, cfg.global_line_color))
             for color in line_colors
         ]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -99,6 +99,17 @@ version = "0.4.1"
 
 [[package]]
 category = "dev"
+description = "A powerful, accurate, and easy-to-use Python library for doing colorspace conversions"
+name = "colorspacious"
+optional = false
+python-versions = "*"
+version = "1.1.2"
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
+category = "dev"
 description = "Code coverage measurement for Python"
 name = "coverage"
 optional = false
@@ -525,7 +536,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "contextlib2", "unittest2"]
 
 [metadata]
-content-hash = "f392515c6505406542c98e311dcda591669cd47ad6b02a0c84c74d5491b7deb4"
+content-hash = "5b94523d9eb3f519370f98de46cb4dc42376819512a0465e162c190f4a5e484f"
 python-versions = "^3.6"
 
 [metadata.files]
@@ -568,6 +579,10 @@ codecov = [
 colorama = [
     {file = "colorama-0.4.1-py2.py3-none-any.whl", hash = "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"},
     {file = "colorama-0.4.1.tar.gz", hash = "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d"},
+]
+colorspacious = [
+    {file = "colorspacious-1.1.2-py2.py3-none-any.whl", hash = "sha256:c78befa603cea5dccb332464e7dd29e96469eebf6cd5133029153d1e69e3fd6f"},
+    {file = "colorspacious-1.1.2.tar.gz", hash = "sha256:5e9072e8cdca889dac445c35c9362a22ccf758e97b00b79ff0d5a7ba3e11b618"},
 ]
 coverage = [
     {file = "coverage-4.5.3-cp26-cp26m-macosx_10_12_x86_64.whl", hash = "sha256:a5d8f29e5ec661143621a8f4de51adfb300d7a476224156a39a392254f70687b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ pytest-cov = "^2.6"
 codecov = "^2.0"
 pytest_cases = "^1.2"
 black = {version = "^18.3-alpha.0", allow-prereleases = true}
+colorspacious = "^1.1.2"
 
 [tool.poetry.scripts]
 corr = 'corrscope.cli:main'

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 import hypothesis.strategies as hs
 import numpy as np
@@ -10,6 +10,7 @@ import corrscope.channel
 import corrscope.corrscope
 from corrscope.channel import ChannelConfig, Channel, DefaultLabel
 from corrscope.corrscope import template_config, CorrScope, BenchmarkMode, Arguments
+from corrscope.renderer import RenderInput
 from corrscope.triggers import NullTriggerConfig
 from corrscope.util import coalesce
 from corrscope.wave import Flatten
@@ -137,10 +138,10 @@ def test_config_channel_integration(
     assert _subsampling == channel.render_stride
 
     # Inspect arguments to renderer.update_main_lines()
-    # datas: List[np.ndarray]
+    datas: List[RenderInput]
     (datas,), kwargs = renderer.update_main_lines.call_args
-    render_data = datas[0]
-    assert len(render_data) == channel._render_samp
+    render_inputs = datas[0]
+    assert len(render_inputs.data) == channel._render_samp
 
     # Inspect arguments to renderer.add_labels().
     (labels,), kwargs = renderer.add_labels.call_args

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -14,7 +14,7 @@ from corrscope.layout import (
     Orientation,
     StereoOrientation,
 )
-from corrscope.renderer import RendererConfig, Renderer
+from corrscope.renderer import RendererConfig, Renderer, RenderInput
 from corrscope.util import ceildiv
 from tests.test_renderer import WIDTH, HEIGHT, RENDER_Y_ZEROS
 
@@ -223,7 +223,7 @@ def test_renderer_layout():
 
     datas = [RENDER_Y_ZEROS] * nplots
     r = Renderer(cfg, lcfg, datas, None, None)
-    r.update_main_lines(datas)
+    r.update_main_lines(RenderInput.wrap_datas(datas))
     layout = r.layout
 
     # 2 columns, 8 rows

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -20,7 +20,7 @@ from corrscope.outputs import (
     FFplayOutputConfig,
     Stop,
 )
-from corrscope.renderer import RendererConfig, Renderer
+from corrscope.renderer import RendererConfig, Renderer, RenderInput
 from tests.test_renderer import RENDER_Y_ZEROS, WIDTH, HEIGHT
 
 if TYPE_CHECKING:
@@ -69,7 +69,7 @@ def test_render_output():
     renderer = Renderer(CFG.render, CFG.layout, datas, None, None)
     out: FFmpegOutput = NULL_FFMPEG_OUTPUT(CFG)
 
-    renderer.update_main_lines(datas)
+    renderer.update_main_lines(RenderInput.wrap_datas(datas))
     out.write_frame(renderer.get_frame())
 
     assert out.close() == 0

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -21,6 +21,7 @@ from corrscope.renderer import (
     AbstractMatplotlibRenderer,
     RendererFrontend,
     CustomLine,
+    RenderInput,
 )
 from corrscope.util import perr
 from corrscope.wave import Flatten
@@ -239,7 +240,7 @@ def verify(r: Renderer, appear: Appearance, datas: List[Optional[np.ndarray]]):
     viewport_width = appear.debug.viewport_width
 
     if draw_fg:
-        r.update_main_lines(datas)
+        r.update_main_lines(RenderInput.wrap_datas(datas))
 
     frame_colors: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (-1, BYTES_PER_PIXEL)
@@ -343,7 +344,7 @@ def test_label_render(label_position: LabelPosition, data, hide_lines):
     r = Renderer(cfg, lcfg, datas, None, None)
     r.add_labels(labels)
     if not hide_lines:
-        r.update_main_lines(datas)
+        r.update_main_lines(RenderInput.wrap_datas(datas))
 
     frame_buffer: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (r.h, r.w, BYTES_PER_PIXEL)
@@ -423,7 +424,7 @@ def verify_res_divisor_rounding(
     try:
         renderer = Renderer(cfg, LayoutConfig(), datas, None, None)
         if not speed_hack:
-            renderer.update_main_lines(datas)
+            renderer.update_main_lines(RenderInput.wrap_datas(datas))
             renderer.get_frame()
     except Exception:
         perr(cfg.divided_width)
@@ -504,7 +505,7 @@ def test_frontend_overrides_backend(mocker: "pytest_mock.MockFixture"):
     data = channel.get_render_around(0)
 
     renderer = Renderer(corr_cfg.render, corr_cfg.layout, [data], [chan_cfg], [channel])
-    renderer.update_main_lines([data])
+    renderer.update_main_lines([RenderInput.stub_new(data)])
     renderer.get_frame()
 
     assert frontend_get_frame.call_count == 1

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -91,7 +91,7 @@ def test_trigger(trigger_cfg, is_odd: bool, post_trigger):
 
     for i, ax in enumerate(axes):
         if i:
-            offset = trigger.get_trigger(x, PerFrameCache())
+            offset = trigger.get_trigger(x, PerFrameCache()).result
             assert offset == x0, offset
         if plot:
             ax.plot(trigger._buffer, label=str(i))
@@ -135,7 +135,7 @@ def test_post_stride(post_trigger):
 
     cache = PerFrameCache()
     for i in range(1, iters):
-        offset = trigger.get_trigger(x0, cache)
+        offset = trigger.get_trigger(x0, cache).result
 
         if not cfg.post_trigger:
             assert (offset - x0) % stride == 0, f"iteration {i}"
@@ -171,7 +171,7 @@ def test_trigger_direction(post_trigger, double_negate):
 
     cache = PerFrameCache()
     for dx in [-10, 10, 0]:
-        assert trigger.get_trigger(index + dx, cache) == index
+        assert trigger.get_trigger(index + dx, cache).result == index
 
 
 def test_trigger_out_of_bounds(trigger_cfg):


### PR DESCRIPTION
Currently uses autogenerated palette based on a fancy perceptually-uniform color space.

## Housekeeping

- [x] Squash "add rainbow" with "only enable rainbow if in config" to unbreak tests
- ~~move code from `corrscope/generate/__init__.py` to the right spot~~ forget it
- [ ] add rainbow unit tests (how?)

## Features

- [x] use default line color for silent waves
- [x] Add on-off GUI toggle, unbreak unit tests
- [x] > I seriously hope the user can select which channels this colourising should be applied to

## Configurability: deferred to Part 2

- [ ] Add optional legend on one side of the screen (check box)
- [ ] add smoothing over time (merge from @sanqui https://github.com/Sanqui/corrscope) (check box)
- [ ] color customization (12 buttons + single text field)

## Color customization

- ~~no customization?~~
- ~~idea: pick light or dark lines.~~
- Current palette is mostly okay-ish, but "a" note looks like gray. oops.
- sanqui: hard-coded list of 12 colors. use directly, or interpolate.
- idea: list of 12 chromatic color pickers in a qt dialog.

> Btw hard coded palette is an awful idea
> I want to be able to customise it to my aesthetics

Fixes #171.