### PR TITLE
Use longest channel for video duration, not first channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 - Add menu items linking to config folder and Github repository (#343)
 - Fix FFmpeg URL, switch to static FFmpeg to reduce user error (#332, #358)
+- Fix bug where videos were truncated if first channel was shorter than the rest (#360)
 
 ## 0.6.1
 

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -237,7 +237,9 @@ class CorrScope:
 
         begin_frame = round(fps * self.cfg.begin_time)
 
-        end_time = coalesce(self.cfg.end_time, self.render_waves[0].get_s())
+        end_time = coalesce(
+            self.cfg.end_time, max(wave.get_s() for wave in self.render_waves)
+        )
         end_frame = fps * end_time
         end_frame = int(end_frame) + 1
 


### PR DESCRIPTION
- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
