### PR TITLE
Fix terminate

### DIFF
--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -548,6 +548,13 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             # t.abort -> Locked.set() is thread-safe (hopefully).
             # It can be called from main thread (not just within CorrThread).
             dlg.canceled.connect(t.abort, Qt.DirectConnection)
+
+            # Don't close the dialog when the user presses Cancel.
+            # Ideally we'd gray out the cancel button, but that's not possible
+            # unless we call QProgressDialog::setCancelButton(),
+            # or better yet replace QProgressDialog with a custom dialog.
+            dlg.canceled.disconnect(dlg.cancel)
+
             t.arg = attr.evolve(
                 arg,
                 on_begin=run_on_ui_thread(dlg.on_begin, (float, float)),
@@ -726,6 +733,9 @@ class CorrThread(qc.QThread):
 
 
 class CorrProgressDialog(qw.QProgressDialog):
+    """should be replaced with a custom dialog someday, with current timestamp,
+    FPS data, etc."""
+
     def __init__(self, parent: Optional[qw.QWidget], title: str):
         super().__init__(parent)
         self.setMinimumWidth(300)


### PR DESCRIPTION
- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.

bug: close the corrscope window with a ffplay preview active.

corrscope and ffplay freezes. ffmpeg is still busy muxing audio and sending to ffplay, which plays it at a leisurely pace.

a similar issue may occur when terminating a render, but ffmpeg is busy writing a shitton of master audio to file.

```
Traceback (most recent call last):
  File "C:\Users\nyanpasu\code\corrscope\corrscope\gui\__init__.py", line 720, in run
    self.corr.play()
  File "C:\Users\nyanpasu\code\corrscope\corrscope\corrscope.py", line 279, in play
    output.terminate()
  File "C:\Users\nyanpasu\code\corrscope\corrscope\outputs.py", line 222, in terminate
    raise exc
  File "C:\Users\nyanpasu\code\corrscope\corrscope\outputs.py", line 215, in terminate
    popen.wait(3)  # timeout=seconds
  File "c:\users\nyanpasu\appdata\local\programs\python\python37\lib\subprocess.py", line 990, in wait
    return self._wait(timeout=timeout)
  File "c:\users\nyanpasu\appdata\local\programs\python\python37\lib\subprocess.py", line 1232, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['ffplay', '-autoexit', '-', '-nostats', '-hide_banner', '-loglevel', 'error']' timed out after 3 seconds
```