### PR TITLE
Build AppVeyor CI binaries on Python 3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changelog
 
+- Build official Win64 binaries on Python 3.8 (the last release to support Windows 7) (#376)
 - Update NumPy so `poetry install` on Python 3.8+ won't build NumPy from source (#371)
 - Fix longstanding crash when prefs.yaml is corrupted, reset settings instead (#377)
 - Atomically save prefs.yaml to prevent file corruption (#377)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/ or
     # https://www.appveyor.com/docs/linux-images-software/
-    - pydir: 'C:\Python36'
+    - pydir: 'C:\Python38'
     - pydir: 'C:\Python38-x64'
   global:
     py: '%pydir%\python.exe'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,9 @@
 #https://github.com/sdispater/poetry/blob/master/.appveyor.yml
 #https://github.com/sdispater/pendulum/blob/master/appveyor.yml
 
-branches:
-  only:
-    - master
+# branches:
+#   only:
+#     - master
 
 image: Visual Studio 2019
 shallow_clone: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,7 +48,8 @@ test_script:
   - 'poetry run codecov'
 
 after_test:
-  - 'if not "%pydir%"=="C:\Python38-x64" appveyor exit'
+  # Skip 32-bit PyInstaller on pull requests, to make CI complete faster.
+  - 'if not "%pydir%"=="C:\Python38-x64" if defined APPVEYOR_PULL_REQUEST_NUMBER appveyor exit'
   # Running pyinstaller is much faster on x64 I think,
   # but the resulting files are 64-bit only.
   - 'poetry build'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ branches:
   only:
     - master
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 shallow_clone: true
 environment:
   matrix:
@@ -16,7 +16,7 @@ environment:
     # https://www.appveyor.com/docs/windows-images-software/ or
     # https://www.appveyor.com/docs/linux-images-software/
     - pydir: 'C:\Python36'
-    - pydir: 'C:\Python37-x64'
+    - pydir: 'C:\Python38-x64'
   global:
     py: '%pydir%\python.exe'
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -48,7 +48,7 @@ test_script:
   - 'poetry run codecov'
 
 after_test:
-  - 'if not "%pydir%"=="C:\Python37-x64" appveyor exit'
+  - 'if not "%pydir%"=="C:\Python38-x64" appveyor exit'
   # Running pyinstaller is much faster on x64 I think,
   # but the resulting files are 64-bit only.
   - 'poetry build'


### PR DESCRIPTION
Python 3.8 is the last release of Python to support Windows 7, which I want to keep supporting for the time being.

Hopefully the latest dependencies, and Python 3.8, actually work on Windows 7. I didn't test myself.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
