### PR TITLE
Fix longstanding crash when prefs.yaml is corrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changelog
 
 - Update NumPy so `poetry install` on Python 3.8+ won't build NumPy from source (#371)
+- Fix longstanding crash when prefs.yaml is corrupted, reset settings instead (#377)
+- Atomically save prefs.yaml to prevent file corruption (#377)
 
 ## 0.7.0
 

--- a/corrscope/config.py
+++ b/corrscope/config.py
@@ -19,6 +19,7 @@ from typing import (
     Any,
     TextIO,
     Union,
+    IO,
 )
 
 import attr
@@ -64,10 +65,6 @@ class MyYAML(YAML):
             with stream.open("w", encoding="utf-8") as f:
                 self.dump_without_corrupting(data, f, **kwargs)
 
-        elif isinstance(stream, TextIO):
-            # Nobody actually calls dump(..., open()). This branch is never taken.
-            self.dump_without_corrupting(data, stream, **kwargs)
-
         elif stream is None:
             # Possibly only called in unit tests, not in production.
             stream = StringIO()
@@ -75,9 +72,8 @@ class MyYAML(YAML):
             return stream.getvalue()
 
         else:
-            raise TypeError(
-                f"stream must be {{Path, TextIO=open(), None}}, but is {type(stream)}"
-            )
+            # with atomic_write(...) as f: dump(..., f)
+            self.dump_without_corrupting(data, stream, **kwargs)
 
     def dump_without_corrupting(self, *args, **kwargs):
         YAML.dump(self, *args, **kwargs)

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -175,7 +175,14 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         super().__init__()
 
         # Load settings.
-        self.pref = gp.load_prefs()
+        prefs_error = None
+        try:
+            self.pref = gp.load_prefs()
+            if not isinstance(self.pref, gp.GlobalPrefs):
+                raise TypeError(f"prefs.yaml contains wrong type {type(self.pref)}")
+        except Exception as e:
+            prefs_error = e
+            self.pref = gp.GlobalPrefs()
 
         # Load UI.
         self.setupUi(self)  # sets windowTitle
@@ -236,6 +243,12 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             )
 
         self.show()
+
+        if prefs_error is not None:
+            TracebackDialog(self).showMessage(
+                "Warning: failed to load global preferences, resetting to default.\n"
+                + format_stack_trace(prefs_error)
+            )
 
     _cfg_path: Optional[Path]
 

--- a/corrscope/settings/global_prefs.py
+++ b/corrscope/settings/global_prefs.py
@@ -1,5 +1,7 @@
 from typing import *
 
+from atomicwrites import atomic_write
+
 from corrscope.config import DumpableAttrs, yaml
 from corrscope.settings import paths
 
@@ -50,4 +52,5 @@ def load_prefs() -> GlobalPrefs:
 
 
 def dump_prefs(pref: GlobalPrefs) -> None:
-    yaml.dump(pref, _PREF_PATH)
+    with atomic_write(_PREF_PATH, overwrite=True) as f:
+        yaml.dump(pref, f)

--- a/poetry.lock
+++ b/poetry.lock
@@ -18,7 +18,7 @@ python-versions = "*"
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -609,7 +609,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "7e4bd31660cb4764c68a7f51487837972530c1426c7902c04ca760d5ef278fa5"
+content-hash = "bb03d24e8ec7fcbf38ca0726736a7cdcd3e3f38a2ad281f522e3aedce1540bfb"
 
 [metadata.files]
 altgraph = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ matplotlib = "^3.1"
 attrs = "^21.2.0"
 PyQt5 = "^5.15.4"
 appdirs = "^1.4.4"
+atomicwrites = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"


### PR DESCRIPTION
## Fix longstanding crash when prefs.yaml is corrupted

Instead, warn the user with a popup dialog, and reset settings to default.

Every few months, a user would report corrscope failing to open due to a corrupted prefs.yaml. This commit should stop all occurrences of that from now on. The next commit will help ensure that we never save corrupted files in the first place.

## Atomically save prefs.yaml to prevent file corruption

This adds a dependency on the atomicwrites package. Note that it was already a transitive dev-dependency, but is now a direct dependency as well.

On Linux, atomicwrites fsyncs the directory after saving. This is unnecessary for consistency after a system crash, and slows down program shutdown slightly. But I'm too lazy to vendor or rewrite the library to not fsync the directory.

----

- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
