### PR TITLE
Update AppVeyor CI to Python 3.8, enable 32-bit binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Fix longstanding crash when prefs.yaml is corrupted, reset settings instead (#377)
 - Atomically save prefs.yaml to prevent file corruption (#377)
 - Fix issue where foobar2000 WAV files fail with message "ValueError: Incomplete wav chunk." (#379)
+- Build Win32 binaries as well as Win64 (#381)
+- Build official Win32/Win64 binaries on Python 3.8 (the last release to support Windows 7) (#381)
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,13 @@ Corrscope is currently in maintenance mode until further notice. The program bas
 - Releases (recommended): https://github.com/corrscope/corrscope/releases
 - Dev Builds: https://ci.appveyor.com/project/nyanpasu64/corrscope/history
 
-Instructions:
+On Windows, download Windows binary releases (.7z files), then double-click `corrscope.exe` or run `corrscope (args)` via CLI.
 
-- Download Windows binary releases (zip files), then double-click `corrscope.exe` or run `corrscope (args)` via CLI.
-- Download cross-platform Python packages (whl), then install Python 3.6+ and run `pip install *.whl`.
+On other operating systems, download cross-platform Python packages (.whl or .tar.gz), then install Python 3.6+ and run `pip install FILENAME.whl`, then run `corr (args)`.
 
 ## Installing from PyPI via Pip (cross-platform, releases)
 
-Install Python 3.6 or above (3.5 will not work).
+Install Python 3.6 or above (3.5 will not work). Note that Python versions other than 3.8 and 3.9 are untested.
 
 ```shell
 # Installs into per-user Python environment.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,15 +8,15 @@ branches:
   only:
     - master
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 shallow_clone: true
 environment:
   matrix:
     # For Python versions available on Appveyor, see
     # https://www.appveyor.com/docs/windows-images-software/ or
     # https://www.appveyor.com/docs/linux-images-software/
-    - pydir: 'C:\Python36'
-    - pydir: 'C:\Python37-x64'
+    - pydir: 'C:\Python38'
+    - pydir: 'C:\Python38-x64'
   global:
     py: '%pydir%\python.exe'
     APPVEYOR_SAVE_CACHE_ON_ERROR: true
@@ -48,9 +48,8 @@ test_script:
   - 'poetry run codecov'
 
 after_test:
-  - 'if not "%pydir%"=="C:\Python37-x64" appveyor exit'
-  # Running pyinstaller is much faster on x64 I think,
-  # but the resulting files are 64-bit only.
+  # Run 32-bit PyInstaller to make CI complete faster.
+  # pyinstaller used to get stuck for minutes on 32-bit builds, but it no longer happens.
   - 'poetry build'
   - 'poetry run pyinstaller corrscope.spec -y'
 

--- a/corrscope/version.py
+++ b/corrscope/version.py
@@ -1,4 +1,6 @@
 import os
+import platform
+import struct
 import sys
 from pathlib import Path
 
@@ -53,6 +55,15 @@ def pyinstaller_write_version() -> str:
     else:
         build_metadata = ""
         version = base_version
+
+    os = platform.system().lower()
+    if os == "windows":
+        os = "win"
+
+    # 32 or 64 bit
+    arch = str(struct.calcsize("P") * 8)
+
+    version = f"{version}-{os}{arch}"
 
     with version_txt.open("w") as txt:
         txt.write(version)


### PR DESCRIPTION
Python 3.8 is the last release of Python to support Windows 7, which I want to keep supporting for the time being.

Hopefully the latest dependencies, and Python 3.8, actually work on Windows 7. I didn't test myself.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
