### PR TITLE
Add .mkv and .webm to GUI render dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix issue where foobar2000 WAV files fail with message "ValueError: Incomplete wav chunk." (#379)
 - Build Win32 binaries as well as Win64 (#381)
 - Build official Win32/Win64 binaries on Python 3.8 (the last release to support Windows 7) (#381)
+- Add .mkv/.webm extensions to "Render to Video" dialog (#383)
 
 ## 0.7.0
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -527,7 +527,12 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
         # Name and extension (no folder).
         video_filename = self.get_save_filename(cli.VIDEO_NAME)
-        filters = ["MP4 files (*.mp4)", "All files (*)"]
+        filters = [
+            "MP4 files (*.mp4)",
+            "Matroska files (*.mkv)",
+            "WebM files (*.webm)",
+            "All files (*)",
+        ]
 
         # Points to either `file_dir` or `render_dir`.
         # Folder is obtained from `dir_ref`.


### PR DESCRIPTION
.mkv works out of the box.

.webm fails to render because Corrscope defaults to telling FFmpeg to encode h.264 video and AAC audio, which don't work in .webm containers. You can workaround this by setting custom video and audio flags (like VP8/VP9 video, perhaps AV1 too, and Ogg/Opus audio), but I'm not sure how to tune the settings. (Leaving both blank works, but is slow to encode, and I don't know if the quality is acceptable.)

Currently this PR doesn't remember the last selected video format, either in the current config, current session, or globally. This is probably a serious annoyance for using non-MP4 video formats. This will not be fixed in this PR, and will be tracked in a separate issue and addressed later (if ever).

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
