### PR TITLE
Render videos in BT.709 colorspace by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Major Changes
 
 - Change `-r/--render` command line flag to take an output path (#382)
+- Render videos in BT.709 colorspace by default (#384)
 
 ### Changelog
 

--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -242,7 +242,10 @@ class FFmpegOutputConfig(IOutputConfig):
     args: str = ""
 
     video_template: str = (
-        "-c:v libx264 -crf 18 -preset superfast -pix_fmt yuv420p -movflags faststart"
+        "-c:v libx264 -crf 18 -preset superfast "
+        "-pix_fmt yuv420p -vf scale=out_color_matrix=bt709 "
+        "-color_range 1 -colorspace bt709 -color_trc bt709 -color_primaries bt709 "
+        "-movflags faststart"
     )
     audio_template: str = "-c:a aac -b:a 384k"
 


### PR DESCRIPTION
This color space has a wider color range, and is recommended by YouTube: https://support.google.com/youtube/answer/1722171?hl=en

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
