### PR TITLE
Fix running `pip install .` in a source checkout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,12 @@
-# https://github.com/sdispater/poetry/issues/826 "conflict with the backend dependencies" with pip 19
-# This bug seems to be fixed, on the latest versions of pip and poetry.
-# But keep this commented just in case.
+# Right now, `pip install [--editable] .` and `pipx install .` work,
+# but `pipx install --editable .` fails with message
+# "No apps associated with package UNKNOWN or its dependencies."
 
-#[build-system]
-#requires = ["poetry>=0.12"]
-#build-backend = "poetry.masonry.api"
+[build-system]
+# "setuptools" is required to make `pip install .` work, due to
+# https://github.com/python-poetry/poetry/issues/3153#issuecomment-727196619 .
+requires = ["setuptools", "poetry_core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "corrscope"


### PR DESCRIPTION
corrscope uses poetry, while pip expects a setuptools project and will create package name UNKNOWN if run without setup.py or pyproject.toml [build-system]. This adds an up-to-date pyproject.toml [build-system] tag.

"setuptools" is required to make `pip install .` work, due to https://github.com/python-poetry/poetry/issues/3153#issuecomment-727196619.

Right now, `pip install [--editable] .` and `pipx install .` work, but `pipx install --editable .` fails with message "No apps associated with package UNKNOWN or its dependencies."

I'm not aware of how to fix this.

- [ ] ~~If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.~~