### PR TITLE
Change wave color based on pitch (synesthesia/chromesthesia) (attempt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.0 (unreleased)
+
+### Features
+
+- Add option to color lines by pitch (#386)
+
 ## 0.7.1
 
 ### Major Changes

--- a/corrscope/channel.py
+++ b/corrscope/channel.py
@@ -41,6 +41,7 @@ class ChannelConfig(DumpableAttrs):
     render_stereo: Optional[FlattenOrStr] = None
 
     line_color: Optional[str] = None
+    color_by_pitch: Optional[bool] = None
 
     # region Legacy Fields
     trigger_width_ratio = Alias("trigger_width")

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -14,8 +14,13 @@ from corrscope.channel import Channel, ChannelConfig, DefaultLabel
 from corrscope.config import KeywordAttrs, DumpEnumAsStr, CorrError, with_units
 from corrscope.layout import LayoutConfig
 from corrscope.outputs import FFmpegOutputConfig, IOutputConfig
-from corrscope.renderer import Renderer, RendererConfig, RendererFrontend
-from corrscope.triggers import CorrelationTriggerConfig, PerFrameCache, SpectrumConfig
+from corrscope.renderer import Renderer, RendererConfig, RendererFrontend, RenderInput
+from corrscope.triggers import (
+    CorrelationTriggerConfig,
+    PerFrameCache,
+    SpectrumConfig,
+    MainTrigger,
+)
 from corrscope.util import pushd, coalesce
 from corrscope.wave import Wave, Flatten, FlattenOrStr
 
@@ -288,7 +293,7 @@ class CorrScope:
                     self.arg.progress(rounded)
                     prev = rounded
 
-                render_datas = []
+                render_inputs = []
                 # Get render-data from each wave.
                 for render_wave, channel in zip(self.render_waves, self.channels):
                     sample = round(render_wave.smp_s * time_seconds)
@@ -296,20 +301,26 @@ class CorrScope:
                     # Get trigger.
                     if not_benchmarking or benchmark_mode == BenchmarkMode.TRIGGER:
                         cache = PerFrameCache()
-                        trigger_sample = channel.trigger.get_trigger(sample, cache)
+
+                        result = channel.trigger.get_trigger(sample, cache)
+                        trigger_sample = result.result
+                        freq_estimate = result.freq_estimate
+
                     else:
                         trigger_sample = sample
+                        freq_estimate = 0
 
                     # Get render data.
                     if should_render:
-                        render_datas.append(channel.get_render_around(trigger_sample))
+                        data = channel.get_render_around(trigger_sample)
+                        render_inputs.append(RenderInput(data, freq_estimate))
 
                 if not should_render:
                     continue
 
                 if not_benchmarking or benchmark_mode >= BenchmarkMode.RENDER:
                     # Render frame
-                    renderer.update_main_lines(render_datas)
+                    renderer.update_main_lines(render_inputs)
                     frame_data = renderer.get_frame()
 
                     if not_benchmarking or benchmark_mode == BenchmarkMode.OUTPUT:

--- a/corrscope/generate/__init__.py
+++ b/corrscope/generate/__init__.py
@@ -1,0 +1,76 @@
+from typing import List
+
+import attr
+import matplotlib as mpl
+import matplotlib.colors
+import numpy as np
+
+TWOPI = 2 * np.pi
+
+
+@attr.dataclass
+class Palette:
+    unclipped: np.ndarray
+    clipped: List[str]
+
+
+def gen_circular_palette() -> Palette:
+    """Return a palette of 12 *distinct* colors in #rrggbb format.
+    The last color is *not* the same as the first.
+    """
+    from colorspacious import cspace_convert
+
+    # Based on https://youtu.be/xAoljeRJ3lU?t=887
+    N = 12
+
+    VALUE = 85
+    SATURATION = 30
+
+    # Phase of color, chosen so output[0] is red
+    HUE = 0.2
+    DIRECTION = -1
+
+    # constant lightness
+    Jp = VALUE * np.ones(N)
+
+    # constant saturation, varying hue
+    t = DIRECTION * np.linspace(0, 1, N, endpoint=False) + HUE
+
+    ap = SATURATION * np.sin(TWOPI * t)
+    bp = SATURATION * np.cos(TWOPI * t)
+
+    # [N](Jp, ap, bp) real
+    Jp_ap_bp = np.column_stack((Jp, ap, bp))
+
+    rgb_raw = cspace_convert(Jp_ap_bp, "CAM02-UCS", "sRGB1")
+
+    rgb = np.clip(rgb_raw, 0, None)
+    rgb_max = np.max(rgb, axis=1).reshape(-1, 1)
+    rgb /= rgb_max
+    assert ((0 <= rgb) * (rgb <= 1)).all()
+
+    print(f"Peak overflow = {np.max(rgb_max - 1)}")
+    print(f"Peak underflow = {np.min(rgb_raw - rgb)}")
+
+    rgb = [mpl.colors.to_hex(c) for c in rgb]
+    print(repr(rgb))
+    return Palette(rgb_raw, rgb)
+
+
+if False:
+    spectral_colors = gen_circular_palette().clipped
+else:
+    spectral_colors = [
+        "#ff8189",
+        "#ff9155",
+        "#ffba37",
+        "#f7ff52",
+        "#95ff85",
+        "#16ffc1",
+        "#00ffff",
+        "#4dccff",
+        "#86acff",
+        "#b599ff",
+        "#ed96ff",
+        "#ff87ca",
+    ]

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -997,6 +997,8 @@ class ConfigModel(PresentationModel):
 @attr.dataclass
 class Column:
     key: str
+
+    # fn(str) -> T. If ValueError is thrown, replaced by `default`.
     cls: Union[type, Callable[[str], Any]]
 
     # `default` is written into config,
@@ -1017,6 +1019,26 @@ def plus_minus_one(value: str) -> int:
 
 
 nope = qc.QVariant()
+
+
+def parse_bool_maybe(s: str) -> Optional[bool]:
+    """Does not throw. But could legally throw ValueError."""
+
+    if not s:
+        return None
+
+    # len(s) >= 1
+    try:
+        return bool(int(s))
+    except ValueError:
+        pass
+
+    s = s.lower()
+    if s[0] in ["t", "y"]:
+        return True
+    if s[0] in ["f", "n"]:
+        return False
+    return None
 
 
 class ChannelModel(qc.QAbstractTableModel):
@@ -1057,6 +1079,7 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("label", str, "", "Label"),
         Column("amplification", float, None, "Amplification\n(override)"),
         Column("line_color", str, None, "Line Color"),
+        Column("color_by_pitch", parse_bool_maybe, None, "Color Lines\nBy Pitch"),
         Column("render_stereo", str, None, "Render Stereo\nDownmix"),
         Column("trigger_width", int, None, "Trigger Width ×"),
         Column("render_width", int, None, "Render Width ×"),

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -167,6 +167,13 @@ class MainWindow(QWidget):
                     self.render__line_width.setMinimum(0.5)
                     self.render__line_width.setSingleStep(0.5)
 
+                with add_row(
+                    s, BoundCheckBox, Both
+                ) as self.render__global_color_by_pitch:
+                    self.render__global_color_by_pitch.setText(
+                        tr("Color Lines By Pitch")
+                    )
+
                 with add_row(s, "", OptionalColorWidget) as self.render__grid_color:
                     pass
 

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -160,6 +160,10 @@ class RendererConfig(
     bg_color: str = "#000000"
     init_line_color: str = default_color()
 
+    @property
+    def global_line_color(self) -> str:
+        return self.init_line_color
+
     grid_color: Optional[str] = None
     stereo_grid_opacity: float = 0.25
 
@@ -177,7 +181,7 @@ class RendererConfig(
 
     @property
     def get_label_color(self):
-        return coalesce(self.label_color_override, self.init_line_color)
+        return coalesce(self.label_color_override, self.global_line_color)
 
     antialiasing: bool = True
 
@@ -289,7 +293,7 @@ class _RendererBackend(ABC):
             line_colors = [None] * self.nplots
 
         self._line_params = [
-            LineParam(color=coalesce(color, cfg.init_line_color))
+            LineParam(color=coalesce(color, cfg.global_line_color))
             for color in line_colors
         ]
 

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Type, Optional, ClassVar, Union
+from typing import TYPE_CHECKING, Type, Optional, ClassVar, Union, TypeVar, Generic
 
 import attr
 import numpy as np
@@ -37,6 +37,11 @@ class _TriggerConfig:
 class MainTriggerConfig(
     _TriggerConfig, KeywordAttrs, always_dump="edge_direction post_trigger post_radius"
 ):
+    if TYPE_CHECKING:
+
+        def __call__(self, wave: "Wave", *args, **kwargs) -> "MainTrigger":
+            return self.cls(wave, self, *args, **kwargs)
+
     # Must be 1 or -1.
     # MainTrigger.__init__() multiplies `wave.amplification *= edge_direction`.
     # get_trigger() should ignore `edge_direction` and look for rising edges.
@@ -61,7 +66,11 @@ class MainTriggerConfig(
 
 class PostTriggerConfig(_TriggerConfig, KeywordAttrs):
     parent: MainTriggerConfig = attr.ib(init=False)  # TODO Unused
-    pass
+
+    if TYPE_CHECKING:
+
+        def __call__(self, wave: "Wave", *args, **kwargs) -> "PostTrigger":
+            return self.cls(wave, self, *args, **kwargs)
 
 
 def register_trigger(config_t: Type[_TriggerConfig]):
@@ -76,7 +85,10 @@ def register_trigger(config_t: Type[_TriggerConfig]):
     return inner
 
 
-class _Trigger(ABC):
+result = TypeVar("result")
+
+
+class _Trigger(ABC, Generic[result]):
     def __init__(
         self,
         wave: "Wave",
@@ -149,7 +161,7 @@ class _Trigger(ABC):
         self._renderer.offset_viewport(self._wave_idx, offset)
 
     @abstractmethod
-    def get_trigger(self, index: int, cache: "PerFrameCache") -> int:
+    def get_trigger(self, index: int, cache: "PerFrameCache") -> result:
         """
         :param index: sample index
         :param cache: Information shared across all stacked triggers,
@@ -163,7 +175,16 @@ class _Trigger(ABC):
         pass
 
 
-class MainTrigger(_Trigger, ABC):
+@attr.dataclass
+class TriggerResult:
+    # new sample index, corresponding to rising edge
+    result: int
+
+    # Estimated frequency in cycle/sec (Hertz). None if unknown.
+    freq_estimate: Optional[float]
+
+
+class MainTrigger(_Trigger[TriggerResult], ABC):
     cfg: MainTriggerConfig
     post: Optional["PostTrigger"]
 
@@ -195,7 +216,7 @@ class MainTrigger(_Trigger, ABC):
         pass
 
 
-class PostTrigger(_Trigger, ABC):
+class PostTrigger(_Trigger[int], ABC):
     """A post-processing trigger should have stride=1,
     and no more post triggers. This is subject to change."""
 
@@ -441,7 +462,7 @@ class CorrelationTrigger(MainTrigger):
     # end setup
 
     # begin per-frame
-    def get_trigger(self, index: int, cache: "PerFrameCache") -> int:
+    def get_trigger(self, index: int, cache: "PerFrameCache") -> TriggerResult:
         N = self._buffer_nsamp
         cfg = self.cfg
 
@@ -525,7 +546,13 @@ class CorrelationTrigger(MainTrigger):
         self.frames_since_spectrum += 1
 
         self.offset_viewport(peak_offset)
-        return trigger
+
+        # period: subsmp/cyc
+        freq_estimate = self.subsmp_s / period if period else None
+        # freq_estimate: cyc/s
+        # If period is 0 (unknown), freq_estimate is None.
+
+        return TriggerResult(trigger, freq_estimate)
 
     def spectrum_rescale_buffer(self, data: np.ndarray) -> None:
         """
@@ -796,5 +823,5 @@ class NullTriggerConfig(MainTriggerConfig):
 
 @register_trigger(NullTriggerConfig)
 class NullTrigger(MainTrigger):
-    def get_trigger(self, index: int, cache: "PerFrameCache") -> int:
-        return index
+    def get_trigger(self, index: int, cache: "PerFrameCache") -> TriggerResult:
+        return TriggerResult(index, None)

--- a/poetry.lock
+++ b/poetry.lock
@@ -110,6 +110,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "colorspacious"
+version = "1.1.2"
+description = "A powerful, accurate, and easy-to-use Python library for doing colorspace conversions"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+numpy = "*"
+
+[[package]]
 name = "coverage"
 version = "5.5"
 description = "Code coverage measurement for Python"
@@ -609,7 +620,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.2"
-content-hash = "bb03d24e8ec7fcbf38ca0726736a7cdcd3e3f38a2ad281f522e3aedce1540bfb"
+content-hash = "04a8ea0aadaea82e45408c37aa39aa70d802e8b497234f775159a9b8d8ac274f"
 
 [metadata.files]
 altgraph = [
@@ -652,6 +663,10 @@ codecov = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+colorspacious = [
+    {file = "colorspacious-1.1.2-py2.py3-none-any.whl", hash = "sha256:c78befa603cea5dccb332464e7dd29e96469eebf6cd5133029153d1e69e3fd6f"},
+    {file = "colorspacious-1.1.2.tar.gz", hash = "sha256:5e9072e8cdca889dac445c35c9362a22ccf758e97b00b79ff0d5a7ba3e11b618"},
 ]
 coverage = [
     {file = "coverage-5.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:b6d534e4b2ab35c9f93f46229363e17f63c53ad01330df9f2d6bd1187e5eaacf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ attrs = "^21.2.0"
 PyQt5 = "^5.15.4"
 appdirs = "^1.4.4"
 atomicwrites = "^1.4.0"
+colorspacious = "^1.1.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.4"

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -1,5 +1,5 @@
 from contextlib import ExitStack
-from typing import Optional
+from typing import Optional, List
 
 import hypothesis.strategies as hs
 import numpy as np
@@ -11,6 +11,7 @@ import corrscope.channel
 import corrscope.corrscope
 from corrscope.channel import ChannelConfig, Channel, DefaultLabel
 from corrscope.corrscope import template_config, CorrScope, BenchmarkMode, Arguments
+from corrscope.renderer import RenderInput
 from corrscope.triggers import NullTriggerConfig
 from corrscope.util import coalesce
 from corrscope.wave import Flatten
@@ -140,10 +141,10 @@ def test_config_channel_integration(
     assert _subsampling == channel.render_stride
 
     # Inspect arguments to renderer.update_main_lines()
-    # datas: List[np.ndarray]
+    datas: List[RenderInput]
     (datas,), kwargs = renderer.update_main_lines.call_args
-    render_data = datas[0]
-    assert len(render_data) == channel._render_samp
+    render_inputs = datas[0]
+    assert len(render_inputs.data) == channel._render_samp
 
     # Inspect arguments to renderer.add_labels().
     (labels,), kwargs = renderer.add_labels.call_args

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -14,7 +14,7 @@ from corrscope.layout import (
     Orientation,
     StereoOrientation,
 )
-from corrscope.renderer import RendererConfig, Renderer
+from corrscope.renderer import RendererConfig, Renderer, RenderInput
 from corrscope.util import ceildiv
 from tests.test_renderer import WIDTH, HEIGHT, RENDER_Y_ZEROS
 
@@ -223,7 +223,7 @@ def test_renderer_layout():
 
     datas = [RENDER_Y_ZEROS] * nplots
     r = Renderer(cfg, lcfg, datas, None, None)
-    r.update_main_lines(datas)
+    r.update_main_lines(RenderInput.wrap_datas(datas))
     layout = r.layout
 
     # 2 columns, 8 rows

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -20,7 +20,7 @@ from corrscope.outputs import (
     FFplayOutputConfig,
     Stop,
 )
-from corrscope.renderer import RendererConfig, Renderer
+from corrscope.renderer import RendererConfig, Renderer, RenderInput
 from tests.test_renderer import RENDER_Y_ZEROS, WIDTH, HEIGHT
 
 if TYPE_CHECKING:
@@ -69,7 +69,7 @@ def test_render_output():
     renderer = Renderer(CFG.render, CFG.layout, datas, None, None)
     out: FFmpegOutput = NULL_FFMPEG_OUTPUT(CFG)
 
-    renderer.update_main_lines(datas)
+    renderer.update_main_lines(RenderInput.wrap_datas(datas))
     out.write_frame(renderer.get_frame())
 
     assert out.close() == 0

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -23,6 +23,7 @@ from corrscope.renderer import (
     AbstractMatplotlibRenderer,
     RendererFrontend,
     CustomLine,
+    RenderInput,
 )
 from corrscope.util import perr
 from corrscope.wave import Flatten
@@ -241,7 +242,7 @@ def verify(r: Renderer, appear: Appearance, datas: List[Optional[np.ndarray]]):
     viewport_width = appear.debug.viewport_width
 
     if draw_fg:
-        r.update_main_lines(datas)
+        r.update_main_lines(RenderInput.wrap_datas(datas))
 
     frame_colors: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (-1, BYTES_PER_PIXEL)
@@ -345,7 +346,7 @@ def test_label_render(label_position: LabelPosition, data, hide_lines):
     r = Renderer(cfg, lcfg, datas, None, None)
     r.add_labels(labels)
     if not hide_lines:
-        r.update_main_lines(datas)
+        r.update_main_lines(RenderInput.wrap_datas(datas))
 
     frame_buffer: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (r.h, r.w, BYTES_PER_PIXEL)
@@ -427,7 +428,7 @@ def verify_res_divisor_rounding(
         try:
             renderer = Renderer(cfg, LayoutConfig(), datas, None, None)
             if not speed_hack:
-                renderer.update_main_lines(datas)
+                renderer.update_main_lines(RenderInput.wrap_datas(datas))
                 renderer.get_frame()
         except Exception:
             perr(cfg.divided_width)
@@ -508,7 +509,7 @@ def test_frontend_overrides_backend(mocker: "pytest_mock.MockFixture"):
     data = channel.get_render_around(0)
 
     renderer = Renderer(corr_cfg.render, corr_cfg.layout, [data], [chan_cfg], [channel])
-    renderer.update_main_lines([data])
+    renderer.update_main_lines([RenderInput.stub_new(data)])
     renderer.get_frame()
 
     assert frontend_get_frame.call_count == 1

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -91,7 +91,7 @@ def test_trigger(trigger_cfg, is_odd: bool, post_trigger):
 
     for i, ax in enumerate(axes):
         if i:
-            offset = trigger.get_trigger(x, PerFrameCache())
+            offset = trigger.get_trigger(x, PerFrameCache()).result
             assert offset == x0, offset
         if plot:
             ax.plot(trigger._buffer, label=str(i))
@@ -135,7 +135,7 @@ def test_post_stride(post_trigger):
 
     cache = PerFrameCache()
     for i in range(1, iters):
-        offset = trigger.get_trigger(x0, cache)
+        offset = trigger.get_trigger(x0, cache).result
 
         if not cfg.post_trigger:
             assert (offset - x0) % stride == 0, f"iteration {i}"
@@ -171,7 +171,7 @@ def test_trigger_direction(post_trigger, double_negate):
 
     cache = PerFrameCache()
     for dx in [-10, 10, 0]:
-        assert trigger.get_trigger(index + dx, cache) == index
+        assert trigger.get_trigger(index + dx, cache).result == index
 
 
 def test_trigger_out_of_bounds(trigger_cfg):


### PR DESCRIPTION
Based on #334.

Currently uses autogenerated palette based on a fancy perceptually-uniform color space.

## Housekeeping

- [ ] add rainbow unit tests (how?)

## Features

- [x] use default line color for silent waves
- [x] Add on-off GUI toggle, unbreak unit tests
- [x] > I seriously hope the user can select which channels this colourising should be applied to

## Configurability (deferred indefinitely)

- [ ] Add optional legend on one side of the screen (check box)
- [ ] add smoothing over time (merge from @sanqui https://github.com/Sanqui/corrscope) (check box)
- [ ] color customization (12 buttons + single text field)

## Color customization (deferred indefinitely)

- ~~no customization?~~
- ~~idea: pick light or dark lines.~~
- Current palette is mostly okay-ish, but "a" note looks like gray. oops.
- sanqui: hard-coded list of 12 colors. use directly, or interpolate.
- idea: list of 12 chromatic color pickers in a qt dialog.

## Issues

The colors come out vibrant in RGB preview, but are partially desaturated by video encoding, and washed-out further by YouTube reencoding (especially hurting blues and purples). The effects can be reduced by increasing line thickness (and resolution as well).

Fixes #171.

- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
