### PR TITLE
Add support for background image and outlines (attempt 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Features
 
 - Add option to color lines by pitch (#386)
+- Add support for background images (#388, @Sanqui)
+- Add support for line outlines (#388, @Sanqui)
 
 ## 0.7.1
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -52,6 +52,7 @@ from corrscope.util import obj_name, iround, coalesce
 from corrscope.wave import Flatten
 
 FILTER_WAV_FILES = ["WAV files (*.wav)"]
+FILTER_IMAGES = ["Images files (*.png *.jpg *.jpeg *.gif)", "All files (*)"]
 
 APP_NAME = f"{corrscope.app_name} {corrscope.__version__}"
 APP_DIR = Path(__file__).parent
@@ -191,6 +192,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
         # Bind UI buttons, etc. Functions block main thread, avoiding race conditions.
         self.master_audio_browse.clicked.connect(self.on_master_audio_browse)
+        self.bg_image_browse.clicked.connect(self.on_bg_image_browse)
 
         self.channelUp.add_shortcut(self.channelsGroup, "ctrl+shift+up")
         self.channelDown.add_shortcut(self.channelsGroup, "ctrl+shift+down")
@@ -444,6 +446,15 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             master_audio = "master_audio"
             self.model[master_audio] = name
             self.model.update_all_bound(master_audio)
+
+    def on_bg_image_browse(self):
+        name = get_open_file_name(
+            self, "Open background image file", self.pref.file_dir_ref, FILTER_IMAGES
+        )
+        if name:
+            bg_image = "render__bg_image"
+            self.model[bg_image] = name
+            self.model.update_all_bound(bg_image)
 
     def on_separate_render_dir_toggled(self, checked: bool):
         self.pref.separate_render_dir = checked

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -160,6 +160,12 @@ class MainWindow(QWidget):
                 with add_row(s, "", BoundColorWidget) as self.render__bg_color:
                     pass
 
+                with add_row(s, tr("Background image"), QHBoxLayout):
+                    with append_widget(s, BoundLineEdit) as self.render__bg_image:
+                        pass
+                    with append_widget(s, QPushButton) as self.bg_image_browse:
+                        self.bg_image_browse.setText(tr("&Browse..."))
+
                 with add_row(s, "", BoundColorWidget) as self.render__init_line_color:
                     pass
 

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -169,16 +169,26 @@ class MainWindow(QWidget):
                 with add_row(s, "", BoundColorWidget) as self.render__init_line_color:
                     pass
 
-                with add_row(s, "", BoundDoubleSpinBox) as self.render__line_width:
-                    self.render__line_width.setMinimum(0.5)
-                    self.render__line_width.setSingleStep(0.5)
-
                 with add_row(
                     s, BoundCheckBox, Both
                 ) as self.render__global_color_by_pitch:
                     self.render__global_color_by_pitch.setText(
                         tr("Color Lines By Pitch")
                     )
+
+                with add_row(s, "", BoundDoubleSpinBox) as self.render__line_width:
+                    self.render__line_width.setMinimum(0.5)
+                    self.render__line_width.setSingleStep(0.5)
+
+                with add_row(
+                    s, tr("Outline Color"), BoundColorWidget
+                ) as self.render__global_line_outline_color:
+                    pass
+
+                with add_row(
+                    s, tr("Outline Width"), BoundDoubleSpinBox
+                ) as self.render__line_outline_width:
+                    self.render__line_outline_width.setSingleStep(0.5)
 
                 with add_row(s, "", OptionalColorWidget) as self.render__grid_color:
                     pass

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -70,6 +70,7 @@ import matplotlib as mpl
 import matplotlib.cm
 import matplotlib.colors
 import matplotlib.image
+import matplotlib.patheffects
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 
@@ -152,6 +153,7 @@ class RendererConfig(
     width: int
     height: int
     line_width: float = with_units("px", default=1.5)
+    line_outline_width: float = with_units("px", default=0.0)
     grid_line_width: float = with_units("px", default=1.0)
 
     @property
@@ -165,6 +167,7 @@ class RendererConfig(
     bg_color: str = "#000000"
     bg_image: str = ""
     init_line_color: str = default_color()
+    global_line_outline_color: str = "#000000"
 
     @property
     def global_line_color(self) -> str:
@@ -668,9 +671,22 @@ class AbstractMatplotlibRenderer(_RendererBackend, ABC):
             for chan_idx, chan_zeros in enumerate(wave_zeros.T):
                 ax = wave_axes[chan_idx]
                 line_color = self._line_params[wave_idx].color
+
                 chan_line: Line2D = ax.plot(
                     xs, chan_zeros, color=line_color, linewidth=line_width
                 )[0]
+
+                if cfg.line_outline_width > 0:
+                    chan_line.set_path_effects(
+                        [
+                            mpl.patheffects.Stroke(
+                                linewidth=cfg.line_width + 2 * cfg.line_outline_width,
+                                foreground=cfg.global_line_outline_color,
+                            ),
+                            mpl.patheffects.Normal(),
+                        ]
+                    )
+
                 wave_lines.append(chan_line)
 
             lines2d.append(wave_lines)

--- a/corrscope/renderer.py
+++ b/corrscope/renderer.py
@@ -66,9 +66,10 @@ if mpl_config_dir in os.environ:
 
 # matplotlib.use() only affects pyplot. We don't use pyplot.
 
-import matplotlib
+import matplotlib as mpl
 import matplotlib.cm
 import matplotlib.colors
+import matplotlib.image
 from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.figure import Figure
 
@@ -162,6 +163,7 @@ class RendererConfig(
         return round(self.height / self.res_divisor)
 
     bg_color: str = "#000000"
+    bg_image: str = ""
     init_line_color: str = default_color()
 
     @property
@@ -505,6 +507,12 @@ class AbstractMatplotlibRenderer(_RendererBackend, ABC):
 
         # Setup background
         self._fig.set_facecolor(cfg.bg_color)
+
+        if cfg.bg_image:
+            img = mpl.image.imread(cfg.bg_image)
+
+            ax = self._fig.add_axes([0, 0, 1, 1])
+            ax.imshow(img)
 
         # Create Axes (using self.lcfg, wave_nchans)
         # _axes2d[wave][chan] = Axes


### PR DESCRIPTION
Based off #336.

- [x] Change the file dialog to allow non-PNG filetypes (.jpg, .jpeg, maybe .gif)
- [x] Resolve merge conflicts, pick a GUI order

![Screenshot_20210728_060408](https://user-images.githubusercontent.com/913957/127326815-606ecf60-2a9a-46e7-864b-b7da05d479c2.png)

The GUI is becoming too complex. Whatever, it's a useful feature, and this PR alone doesn't make the GUI *that much* worse. And hopefully someday I'll fix it... someday... if only 😿

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
