### PR TITLE
Fix passing absolute .wav paths into corrscope CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - Add support for background images (#388, @Sanqui)
 - Add support for line outlines (#388, @Sanqui)
 
+### Changelog
+
+- Fix passing absolute .wav paths into corrscope CLI (#398)
+
 ## 0.7.1
 
 ### Major Changes

--- a/corrscope/cli.py
+++ b/corrscope/cli.py
@@ -1,4 +1,5 @@
 import sys
+from glob import glob
 from pathlib import Path
 from typing import Optional, List, Tuple, Union, cast, TypeVar
 
@@ -167,7 +168,7 @@ def main(
 
         else:
             # Load one or more wav files.
-            matches = sorted(Path().glob(name))
+            matches = sorted([Path(s) for s in glob(name)])
             if not matches:
                 matches = [path]
                 if not path.exists():


### PR DESCRIPTION
- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
- [x] Add test