### PR TITLE
Rewrite correlation trigger using overlap-save on unwindowed data

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -6,23 +6,15 @@
     <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="ourVersions">
         <value>
-          <list size="2">
-            <item index="0" class="java.lang.String" itemvalue="3.6" />
-            <item index="1" class="java.lang.String" itemvalue="3.7" />
+          <list size="3">
+            <item index="0" class="java.lang.String" itemvalue="3.8" />
+            <item index="1" class="java.lang.String" itemvalue="3.9" />
+            <item index="2" class="java.lang.String" itemvalue="3.10" />
           </list>
         </value>
       </option>
     </inspection_tool>
     <inspection_tool class="PyDataclassInspection" enabled="false" level="WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoredPackages">
-        <value>
-          <list size="1">
-            <item index="0" class="java.lang.String" itemvalue="PyQt5" />
-          </list>
-        </value>
-      </option>
-    </inspection_tool>
     <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>
@@ -34,12 +26,5 @@
       </option>
     </inspection_tool>
     <inspection_tool class="PyPep8NamingInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
-    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="ignoredIdentifiers">
-        <list>
-          <option value="numpy.core.multiarray.ndarray.__getitem__" />
-        </list>
-      </option>
-    </inspection_tool>
   </profile>
 </component>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 - Add support for background images (#388, @Sanqui)
 - Add support for line outlines (#388, @Sanqui)
 
+### Major Changes
+
+- Rewrite the trigger algorithm to enhance determinism (#403)
+    - Triggering still makes mistakes, especially when DC offset varies within a frame (eg. NES 75% pulse changing volumes). This may be addressed in the future.
+
 ### Changelog
 
 - Fix passing absolute .wav paths into corrscope CLI (#398)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Rewrite the trigger algorithm to enhance determinism (#403)
     - Triggering still makes mistakes, especially when DC offset varies within a frame (eg. NES 75% pulse changing volumes). This may be addressed in the future.
+    - Changed default triggering settings as well.
 
 ### Changelog
 

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -294,6 +294,7 @@ class CorrScope:
                     prev = rounded
 
                 render_inputs = []
+                trigger_samples = []
                 # Get render-data from each wave.
                 for render_wave, channel in zip(self.render_waves, self.channels):
                     sample = round(render_wave.smp_s * time_seconds)
@@ -312,6 +313,7 @@ class CorrScope:
 
                     # Get render data.
                     if should_render:
+                        trigger_samples.append(trigger_sample)
                         data = channel.get_render_around(trigger_sample)
                         render_inputs.append(RenderInput(data, freq_estimate))
 
@@ -320,7 +322,7 @@ class CorrScope:
 
                 if not_benchmarking or benchmark_mode >= BenchmarkMode.RENDER:
                     # Render frame
-                    renderer.update_main_lines(render_inputs)
+                    renderer.update_main_lines(render_inputs, trigger_samples)
                     frame_data = renderer.get_frame()
 
                     if not_benchmarking or benchmark_mode == BenchmarkMode.OUTPUT:

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -113,7 +113,7 @@ def template_config(**kwargs) -> Config:
         master_audio="",
         fps=_FPS,
         amplification=1,
-        trigger_ms=60,
+        trigger_ms=40,
         render_ms=40,
         trigger_subsampling=1,
         render_subsampling=2,

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -359,7 +359,7 @@ class MainWindow(QWidget):
                     name="trigger__slope_width",
                 ):
                     s.widget.setMinimum(0)
-                    s.widget.setMaximum(0.5)
+                    s.widget.setMaximum(2)
                     s.widget.setSingleStep(0.02)
 
             with append_widget(

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -416,13 +416,14 @@ class CorrelationTrigger(MainTrigger):
 
         cfg = self.cfg
         if cfg.slope_strength:
-            slope_finder = np.zeros(self.A + self.B)
-
             slope_width = max(iround(cfg.slope_width * period), 1)
             slope_strength = cfg.slope_strength * cfg.buffer_falloff
 
-            slope_finder[self.A - slope_width : self.A] = -slope_strength
-            slope_finder[self.A : self.A + slope_width] = slope_strength
+            slope_finder = np.empty(self.A + self.B, dtype=f32)  # type: np.ndarray[f32]
+            slope_finder[: self.A] = -slope_strength / 2
+            slope_finder[self.A :] = slope_strength / 2
+
+            slope_finder *= windows.gaussian(self.A + self.B, std=slope_width)
             return slope_finder
         else:
             return None

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -305,7 +305,7 @@ class CorrelationTriggerConfig(
     def __attrs_post_init__(self) -> None:
         MainTriggerConfig.__attrs_post_init__(self)
 
-        validate_param(self, "slope_width", 0, 0.5)
+        # Don't validate slope_width.
 
         validate_param(self, "responsiveness", 0, 1)
         # TODO trigger_falloff >= 0
@@ -416,7 +416,8 @@ class CorrelationTrigger(MainTrigger):
 
         cfg = self.cfg
         if cfg.slope_strength:
-            slope_width = max(iround(cfg.slope_width * period), 1)
+            # noinspection PyTypeChecker
+            slope_width: float = np.clip(cfg.slope_width * period, 1.0, self.A / 3)
             slope_strength = cfg.slope_strength * cfg.buffer_falloff
 
             slope_finder = np.empty(self.A + self.B, dtype=f32)  # type: np.ndarray[f32]

--- a/corrscope/wave.py
+++ b/corrscope/wave.py
@@ -218,7 +218,7 @@ class Wave:
             data = data.reshape(-1, 1)
         return data
 
-    def _get(self, begin: int, end: int, subsampling: int) -> np.ndarray:
+    def get_padded(self, begin: int, end: int, subsampling: int) -> np.ndarray:
         """Copies self.data[begin:end] with zero-padding."""
         if 0 <= begin and end <= self.nsamp:
             return self[begin:end:subsampling]
@@ -264,7 +264,7 @@ class Wave:
 
         begin = sample - (return_nsamp // 2) * stride
         end = begin + return_nsamp * stride
-        return self._get(begin, end, stride)
+        return self.get_padded(begin, end, stride)
 
     def get_s(self) -> float:
         """

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -142,7 +142,7 @@ def test_config_channel_integration(
 
     # Inspect arguments to renderer.update_main_lines()
     datas: List[RenderInput]
-    (datas,), kwargs = renderer.update_main_lines.call_args
+    (datas, *args), kwargs = renderer.update_main_lines.call_args
     render_inputs = datas[0]
     assert len(render_inputs.data) == channel._render_samp
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -223,7 +223,7 @@ def test_renderer_layout():
 
     datas = [RENDER_Y_ZEROS] * nplots
     r = Renderer(cfg, lcfg, datas, None, None)
-    r.update_main_lines(RenderInput.wrap_datas(datas))
+    r.update_main_lines(RenderInput.wrap_datas(datas), [0] * nplots)
     layout = r.layout
 
     # 2 columns, 8 rows

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -69,7 +69,7 @@ def test_render_output():
     renderer = Renderer(CFG.render, CFG.layout, datas, None, None)
     out: FFmpegOutput = NULL_FFMPEG_OUTPUT(CFG)
 
-    renderer.update_main_lines(RenderInput.wrap_datas(datas))
+    renderer.update_main_lines(RenderInput.wrap_datas(datas), [0])
     out.write_frame(renderer.get_frame())
 
     assert out.close() == 0

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -242,7 +242,7 @@ def verify(r: Renderer, appear: Appearance, datas: List[Optional[np.ndarray]]):
     viewport_width = appear.debug.viewport_width
 
     if draw_fg:
-        r.update_main_lines(RenderInput.wrap_datas(datas))
+        r.update_main_lines(RenderInput.wrap_datas(datas), [0] * len(datas))
 
     frame_colors: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (-1, BYTES_PER_PIXEL)
@@ -346,7 +346,7 @@ def test_label_render(label_position: LabelPosition, data, hide_lines):
     r = Renderer(cfg, lcfg, datas, None, None)
     r.add_labels(labels)
     if not hide_lines:
-        r.update_main_lines(RenderInput.wrap_datas(datas))
+        r.update_main_lines(RenderInput.wrap_datas(datas), [0] * nplots)
 
     frame_buffer: np.ndarray = np.frombuffer(r.get_frame(), dtype=np.uint8).reshape(
         (r.h, r.w, BYTES_PER_PIXEL)
@@ -428,7 +428,9 @@ def verify_res_divisor_rounding(
         try:
             renderer = Renderer(cfg, LayoutConfig(), datas, None, None)
             if not speed_hack:
-                renderer.update_main_lines(RenderInput.wrap_datas(datas))
+                renderer.update_main_lines(
+                    RenderInput.wrap_datas(datas), [0] * len(datas)
+                )
                 renderer.get_frame()
         except Exception:
             perr(cfg.divided_width)
@@ -509,7 +511,7 @@ def test_frontend_overrides_backend(mocker: "pytest_mock.MockFixture"):
     data = channel.get_render_around(0)
 
     renderer = Renderer(corr_cfg.render, corr_cfg.layout, [data], [chan_cfg], [channel])
-    renderer.update_main_lines([RenderInput.stub_new(data)])
+    renderer.update_main_lines([RenderInput.stub_new(data)], [0])
     renderer.get_frame()
 
     assert frontend_get_frame.call_count == 1

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -16,7 +16,6 @@ from corrscope.triggers import (
     PerFrameCache,
     ZeroCrossingTriggerConfig,
     SpectrumConfig,
-    correlate_data,
     correlate_spectrum,
 )
 from corrscope.wave import Wave
@@ -35,7 +34,7 @@ def trigger_template(**kwargs) -> CorrelationTriggerConfig:
 
 
 @fixture
-@parametrize("trigger_diameter", [None, 0.5])
+@parametrize("trigger_diameter", [0.5, 1.0])
 @parametrize("pitch_tracking", [None, SpectrumConfig()])
 @parametrize("slope_strength", [0, 100])
 @parametrize("sign_strength", [0, 1])
@@ -94,7 +93,7 @@ def test_trigger(trigger_cfg, is_odd: bool, post_trigger):
             offset = trigger.get_trigger(x, PerFrameCache()).result
             assert offset == x0, offset
         if plot:
-            ax.plot(trigger._buffer, label=str(i))
+            ax.plot(trigger._corr_buffer, label=str(i))
             ax.grid()
 
     if plot:
@@ -241,8 +240,7 @@ def test_post_trigger_radius():
 # Test pitch-tracking (spectrum)
 
 
-@parametrize("correlate", [correlate_data, correlate_spectrum])
-def test_correlate_offset(correlate):
+def test_correlate_offset():
     """
     Catches bug where writing N instead of Ncorr
     prevented function from returning positive numbers.
@@ -256,7 +254,7 @@ def test_correlate_offset(correlate):
     # Ensure autocorrelation on random data returns peak at 0.
     N = 100
     spectrum = np.random.random(N)
-    assert correlate(spectrum, spectrum, 12).peak == approx(0)
+    assert correlate_spectrum(spectrum, spectrum, 12).peak == approx(0)
 
     # Ensure cross-correlation of time-shifted impulses works.
     # Assume wave where y=[i==99].
@@ -267,10 +265,12 @@ def test_correlate_offset(correlate):
 
     # We need to slide `left` to the right by 10 samples, and vice versa.
     for radius in [None, 12]:
-        assert correlate(data=left, prev_buffer=right, radius=radius).peak == approx(10)
-        assert correlate(data=right, prev_buffer=left, radius=radius).peak == approx(
-            -10
-        )
+        assert correlate_spectrum(
+            data=left, prev_buffer=right, radius=radius
+        ).peak == approx(10)
+        assert correlate_spectrum(
+            data=right, prev_buffer=left, radius=radius
+        ).peak == approx(-10)
 
 
 # Test the ability to load legacy TriggerConfig


### PR DESCRIPTION
The previous algorithm slides the history buffer and edge detector across an equally sized slice of the input wave, which suffers from edge effects. It mitigates edge effects by multiplying the input wave slice by a window, but unfortunately this biases corrscope towards picking points near the actual point in time, which causes inconsistent triggering and jitter. In corrscope videos I've made or watched, I _consistently_ noticed bad triggering drifting towards alignment, bad triggering that remains for the duration of the note, or (with low buffer strengths or ambiguous waveforms) constant jittering between multiple edges with near-identical scores.

This PR introduces an overlap-save algorithm, which takes a larger slice of the input wave than the history buffer and edge detector, and only slides the history/edge within the input wave. This algorithm is fully free of edge effects within the sliding region, making it much more deterministic (not influenced by wave offsets) than before. This improves (but does not solve) bad triggering, and does not fix notes influencing other notes (which would require more heuristics), but essentially solves the jittering problem (caused by nondeterministic triggering) which previously occurred at low or zero buffer strengths.

## Summary

The data read from the input _wave (length L) is longer than the correlation buffer (length A+B), to ensure that when sliding the buffer across the wave, no edge effects are encountered. This is inspired by overlap-save block convolution (or valid convolution), but adapted to cross-correlation.

## TODO

- https://docs.google.com/document/d/1iIDzB81zcaW71ZshC8yOW7p_cOLEYzJ3mrvHQa-lKH8/edit
- [x] Read/test for errors related to stride (tbh I want to allow increasing/decreasing trigger time for individual channels independent of stride)
- [x] Decrease default trigger width to 40ms from 60
- [x] ~~Move "skip sign triggering" to a separate PR~~ rejected
- [ ] Add "skip buffer triggering" and "skip edge triggering"
- [ ] skip correlation altogether if both buffer and step triggering are off
- [x] ~~Remove mean subtraction for extra determinism?~~ rejected (actually mean subtraction does nothing but ~~take up time~~ and affect `get_period()`, since we removed windowing afterwards?)
- [x] ~~Better or worse for nes tri?~~ close enough
- [ ] Review code
- [x] Update changelog

Our unit tests have revealed that we no longer prefer triggering near the initial position to triggering at the edges at *all*. This may result in less smooth movement. This might be a problem for fairly long waves where 2 or 3 fill the entire trigger buffer, resulting in more jerky movement (up to ±1.5 periods) than otherwise (though at <120 FPS you're bound to have jerky movement).

Fixes #248.