### PR TITLE
Add DC removal rate control, replace edge kernel with running sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Major Changes
 
-- Rewrite the trigger algorithm to enhance determinism (#403)
+- Rewrite the trigger algorithm to enhance determinism and reduce errors when DC offset varies within a frame (#403, #408)
     - Triggering still makes mistakes, especially when DC offset varies within a frame (eg. NES 75% pulse changing volumes). This may be addressed in the future.
     - Changed default triggering settings as well.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - Fix passing absolute .wav paths into corrscope CLI (#398)
 - Fix preview error when clearing "Trigger/Render Width" table cells (#407)
+- Add control for DC removal rate (#408)
 
 ## 0.7.1
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -1095,6 +1095,7 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("render_stereo", str, None, "Render Stereo\nDownmix"),
         Column("trigger_width", int, 1, "Trigger Width ×", always_show=True),
         Column("render_width", int, 1, "Render Width ×", always_show=True),
+        Column("trigger__mean_responsiveness", float, None, "DC Removal\nRate"),
         Column("trigger__sign_strength", float, None),
         Column("trigger__buffer_strength", float, None),
         Column("trigger__responsiveness", float, None, "Buffer\nResponsiveness"),

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -297,6 +297,17 @@ class MainWindow(QWidget):
             ):
                 with add_row(
                     s,
+                    tr("DC Removal Rate"),
+                    BoundDoubleSpinBox,
+                    name="trigger__mean_responsiveness",
+                    minimum=0,
+                    maximum=1,
+                    singleStep=0.25,
+                ):
+                    pass
+
+                with add_row(
+                    s,
                     tr("Sign Triggering\n(for triangle waves)"),
                     BoundDoubleSpinBox,
                     name="trigger__sign_strength",

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -372,12 +372,6 @@ class CorrelationTrigger(MainTrigger):
         # Updated with tightly windowed old data at various pitches.
         self._corr_buffer = np.zeros(self.A + self.B, dtype=f32)
 
-        # (const) Added to self._buffer. Nonzero if edge triggering is nonzero.
-        # Left half is -edge_strength, right half is +edge_strength.
-        # ASCII art: --._|‾'--
-        self._edge_finder = self._calc_step()
-        assert self._edge_finder.dtype == f32
-
         self._prev_mean = 0.0
         # Will be overwritten on the first frame.
         self._prev_period = None
@@ -396,22 +390,6 @@ class CorrelationTrigger(MainTrigger):
             )
         else:
             self._spectrum_calc = DummySpectrum()
-
-    def _calc_step(self) -> np.ndarray:
-        """Step function used for approximate edge triggering. Has length A+B."""
-
-        # Increasing buffer_falloff (width of buffer)
-        # causes buffer to affect triggering, more than the step function.
-        # So we multiply edge_strength (step function height) by buffer_falloff.
-
-        cfg = self.cfg
-        edge_strength = cfg.edge_strength * cfg.buffer_falloff
-
-        step = np.empty(self.A + self.B, dtype=f32)  # type: np.ndarray[f32]
-        step[: self.A] = -edge_strength / 2
-        step[self.A :] = edge_strength / 2
-        step *= windows.gaussian(self.A + self.B, std=self.A / 3)
-        return step
 
     def _calc_slope_finder(self, period: float) -> Optional[np.ndarray]:
         """Called whenever period changes substantially.
@@ -444,7 +422,7 @@ class CorrelationTrigger(MainTrigger):
         # Convert sizes to full samples (not trigger subsamples) when indexing into
         # _wave.
 
-        # _trigger_diameter is defined as inclusive. The length of correlate_valid()'s
+        # _trigger_diameter is defined as inclusive. The length of find_peak()'s
         # corr variable is (A + _trigger_diameter + B) - (A + B) + 1, or
         # _trigger_diameter + 1. This gives us a possible triggering range of
         # _trigger_diameter inclusive, which is what we want.
@@ -496,11 +474,29 @@ class CorrelationTrigger(MainTrigger):
         else:
             slope_finder = self._prev_slope_finder
 
+        if cfg.edge_strength:
+            # I want a half-open cumsum, where edge_score[0] = 0, [1] = data[A], [2] =
+            # data[A] + data[A+1], etc. But cumsum is inclusive, which causes tests to
+            # fail. So subtract 1 from the input range.
+            edge_score = np.cumsum(data[self.A - 1 : len(data) - self.B])
+
+            # The optimal edge alignment is the *minimum* cumulative sum, so invert
+            # the cumsum so the minimum amplitude maps to the highest score.
+            edge_score *= -cfg.edge_strength
+        else:
+            edge_score = None
+
         # array[A+B] Amplitude
         corr_kernel: np.ndarray = self._corr_buffer * cfg.buffer_strength
-        corr_kernel += self._edge_finder
         if slope_finder is not None:
             corr_kernel += slope_finder
+
+        # `corr[x]` = correlation of kernel placed at position `x` in data.
+        # `corr_kernel` is not allowed to move past the boundaries of `data`.
+        corr = signal.correlate_valid(data, corr_kernel)
+
+        if edge_score is not None:
+            corr += edge_score
 
         # Don't pick peaks more than `period * trigger_radius_periods` away from the
         # center.
@@ -509,17 +505,11 @@ class CorrelationTrigger(MainTrigger):
         else:
             trigger_radius = None
 
-        def correlate_valid(
-            data: np.ndarray, corr_kernel: np.ndarray, radius: Optional[int]
-        ) -> int:
-            """Returns kernel offset (≥ 0) relative to data, which maximizes correlation.
-            kernel is not allowed to move past the boundaries of data.
-
-            If radius is set, the returned offset is limited to ±radius from the center of
-            correlation.
+        def find_peak(corr: np.ndarray, radius: Optional[int]) -> int:
+            """If radius is set, the returned offset is limited to ±radius from the
+            center of correlation.
             """
             # returns double, not single/f32
-            corr = signal.correlate_valid(data, corr_kernel)
             begin_offset = 0
 
             if radius is not None:
@@ -547,7 +537,7 @@ class CorrelationTrigger(MainTrigger):
             return peak_offset
 
         # Find correlation peak.
-        peak_offset = correlate_valid(data, corr_kernel, trigger_radius)
+        peak_offset = find_peak(corr, trigger_radius)
         trigger = trigger_begin + stride * (peak_offset)
 
         del data


### PR DESCRIPTION
Previously we got triggering errors where instead of edge triggering scores being decided by the waveform around the trigger point, it was influenced by distant parts of the waveform moving across the wide sloped portion of the edge detector kernel.

This PR replaces the edge kernel with a running sum, which acts like an infinitely wide step kernel that the input data slides *within*. As a result, the difference between the edge scores of two trigger points is solely determined by the data between those points. (The step kernel and history buffer are unaffected and still slide within the data.)

This makes triggering less likely to fail. However the global scoring system sometimes prioritizes bad edges in good regions of the document. This will be reexamined later.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
- [x] Make DC removal always written
- [x] Properly remove mean from data passed into period calculation