### PR TITLE
Switch to QtPy, add PyQt6 support alongside PyQt5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Add option to color lines by pitch (#386)
 - Add support for background images (#388, @Sanqui)
 - Add support for line outlines (#388, @Sanqui)
+- Add Mac and M1 support (#415, @beetrootpaul)
 
 ### Major Changes
 

--- a/README.md
+++ b/README.md
@@ -22,35 +22,45 @@ Corrscope is currently in semi-active development. The program basically works a
 
 - FFmpeg
 
-## Installation
+## Installing Prebuilt Windows Binaries
 
-- Releases (recommended): https://github.com/corrscope/corrscope/releases
-- Dev Builds: https://ci.appveyor.com/project/nyanpasu64/corrscope/history
+On Windows, download Windows binary releases (.7z files) from the [Releases page](https://github.com/corrscope/corrscope/releases), then double-click `corrscope.exe` or run `corrscope (args)` via CLI.
 
-On Windows, download Windows binary releases (.7z files), then double-click `corrscope.exe` or run `corrscope (args)` via CLI.
+## Installing through Python
 
-On other operating systems, download cross-platform Python packages (.whl or .tar.gz), then install Python 3.6+ and run `pip install FILENAME.whl`, then run `corr (args)`.
+Install Python 3.8 or above, then install corrscope using your method of choice. Afterwards, open a terminal and run `corr (args)`.
 
-## Installing from PyPI via Pip (cross-platform, releases)
+### Installing from PyPI via pipx (cross-platform, releases)
 
-Install Python 3.6 or above (3.5 will not work). Note that Python versions other than 3.8 and 3.9 are untested.
+pipx creates an isolated environment for each program, and adds their binaries into PATH. I find this most reliable in practice, though it runs into issues after upgrading system Python in-place.
 
-```shell
-# Installs into per-user Python environment.
-pip3 install --user corrscope
-corr (args)
-```
+- Install pipx using either your Linux package manager, `pip3 install --user pipx`, or `pip install --user pipx`.
+- Run `pipx install corrscope[qt5]`
+    - On Linux, to add support for native Qt themes, instead run `pipx install --system-site-packages corrscope[qt5]`
+    - On M1 Mac, instead run `pipx install corrscope[qt6]`
+
+### Installing from PyPI via Pip (cross-platform, releases)
+
+pip installs packages into a per-user Python environment. This has the disadvantage that each program you install influences the packages seen by other programs. It might run into issues when upgrading system Python in-place; I haven't tested.
+
+- If necessary, install pip using your Linux package manager.
+- Run `pip3 install --user corrscope[qt5]`
+    - On M1 Mac, instead run `pip3 install --user corrscope[qt6]`
+
+## Dev builds (Windows)
+
+Windows dev builds are compiled automatically, and available at https://ci.appveyor.com/project/nyanpasu64/corrscope/history.
+
+Installing dev builds on non-Windows platforms without cloning the repo (eg. Git URLs or .whl files) is not supported yet. Fixes are welcome.
 
 ## Running from Source Code (cross-platform, dev master)
 
-Install Python 3.6 or above (3.5 will not work), and Poetry.
+Install Python 3.8 or above, and Poetry. My preference is to run `pipx install poetry`. You can alternatively use the Poetry installer via `curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python`, but in the past, updating via `poetry self update` has broken and left me with no Poetry at all, requiring reinstalling.
 
 ```shell
-# Installs into an isolated environment.
-# Install Poetry (only do this once)
-curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
 cd path/to/corrscope
-poetry install corrscope  # --develop is implied
+poetry install -E qt5  # --develop is implied
+# On M1 Mac, instead run `poetry install -E qt6`.
 poetry run corr (args)
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,38 +22,40 @@ Corrscope is currently in semi-active development. The program basically works a
 
 - FFmpeg
 
-## Installing Prebuilt Windows Binaries
+## Installation
+
+### Installing Prebuilt Windows Binaries
 
 On Windows, download Windows binary releases (.7z files) from the [Releases page](https://github.com/corrscope/corrscope/releases), then double-click `corrscope.exe` or run `corrscope (args)` via CLI.
-
-## Installing through Python
-
-Install Python 3.8 or above, then install corrscope using your method of choice. Afterwards, open a terminal and run `corr (args)`.
 
 ### Installing from PyPI via pipx (cross-platform, releases)
 
 pipx creates an isolated environment for each program, and adds their binaries into PATH. I find this most reliable in practice, though it runs into issues after upgrading system Python in-place.
 
+- Install Python 3.8 or above.
 - Install pipx using either your Linux package manager, `pip3 install --user pipx`, or `pip install --user pipx`.
 - Run `pipx install corrscope[qt5]`
     - On Linux, to add support for native Qt themes, instead run `pipx install --system-site-packages corrscope[qt5]`
     - On M1 Mac, instead run `pipx install corrscope[qt6]`
+- Open a terminal and run `corr (args)`.
 
 ### Installing from PyPI via Pip (cross-platform, releases)
 
 pip installs packages into a per-user Python environment. This has the disadvantage that each program you install influences the packages seen by other programs. It might run into issues when upgrading system Python in-place; I haven't tested.
 
+- Install Python 3.8 or above.
 - If necessary, install pip using your Linux package manager.
 - Run `pip3 install --user corrscope[qt5]`
     - On M1 Mac, instead run `pip3 install --user corrscope[qt6]`
+- Open a terminal and run `corr (args)`.
 
-## Dev builds (Windows)
+### Dev builds (Windows)
 
 Windows dev builds are compiled automatically, and available at https://ci.appveyor.com/project/nyanpasu64/corrscope/history.
 
 Installing dev builds on non-Windows platforms without cloning the repo (eg. Git URLs or .whl files) is not supported yet. Fixes are welcome.
 
-## Running from Source Code (cross-platform, dev master)
+### Running from Source Code (cross-platform, dev master)
 
 Install Python 3.8 or above, and Poetry. My preference is to run `pipx install poetry`. You can alternatively use the Poetry installer via `curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python`, but in the past, updating via `poetry self update` has broken and left me with no Poetry at all, requiring reinstalling.
 
@@ -94,6 +96,18 @@ poetry run corr (args)
 
 1. Render and encode video (requires ffmpeg)
     - `corrscope master.yaml -r/--render file.mp4` (other file extensions supported)
+
+## Mac-specific Issues
+
+### M1 Slowdown
+
+On M1 processors, if you open preview, after 40 or so seconds, the preview may suddenly slow down and audio will stop playing. This is because macOS thinks ffplay is the active app, and Corrscope is a background job burning CPU, so it moves Corrscope to an Efficiency core, slowing it down.
+
+There is no fix for this issue at the moment. As a workaround, you can click on Corrscope's window to avoid the slowdown, and drag it aside so it doesn't obstruct the preview.
+
+### Gatekeeper
+
+On Mac, if you render a video file, in some cases (eg. IINA video player) you may not be able to open the resulting files. Gatekeeper will print an error saying '"filename.mp4" cannot be opened because it is from an unidentified developer.'. If you see this message, try opening the file again. Once you silence the error once, it should not reappear.
 
 ## Contributing
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ install:
 
   # Prevents: "The current Python version (2.7.15) is not supported by the project (^3.6)"
   - 'set PATH=%pydir%;%pydir%\bin;%pydir%\Scripts;%PATH%'
-  - 'poetry install -v'  # don't pass --no-dev
+  - 'poetry install -v -E qt5'  # don't pass --no-dev
 
 build_script:
   - exit

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -8,11 +8,11 @@ from pathlib import Path
 from types import MethodType
 from typing import Optional, List, Any, Tuple, Callable, Union, Dict, Sequence, NewType
 
-import PyQt5.QtCore as qc
-import PyQt5.QtWidgets as qw
+import qtpy.QtCore as qc
+import qtpy.QtWidgets as qw
 import attr
-from PyQt5.QtCore import QModelIndex, Qt, QVariant
-from PyQt5.QtGui import QFont, QCloseEvent, QDesktopServices
+from qtpy.QtCore import QModelIndex, Qt, QVariant
+from qtpy.QtGui import QFont, QCloseEvent, QDesktopServices
 
 import corrscope
 import corrscope.settings.global_prefs as gp

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -36,6 +36,7 @@ from corrscope.gui.model_bind import (
     BoundComboBox,
 )
 from corrscope.gui.util import color2hex, Locked, find_ranges, TracebackDialog
+from corrscope.gui.version_common import QT6
 from corrscope.gui.view_mainwindow import MainWindow as Ui_MainWindow
 from corrscope.gui.widgets import ChannelTableView, ShortcutButton
 from corrscope.layout import Orientation, StereoOrientation
@@ -83,7 +84,8 @@ def gui_main(cfg_or_path: Union[Config, Path]):
 
     # qw.QApplication.setStyle('fusion')
     QApp = qw.QApplication
-    QApp.setAttribute(qc.Qt.AA_EnableHighDpiScaling)
+    if not QT6:
+        QApp.setAttribute(qc.Qt.AA_EnableHighDpiScaling)
 
     app = qw.QApplication(sys.argv)
 
@@ -674,12 +676,12 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         return self.model.cfg
 
     # Misc.
-    @qc.pyqtSlot()
+    @qc.Slot()
     def on_action_website(self):
         website_url = r"https://github.com/corrscope/corrscope/"
         QDesktopServices.openUrl(qc.QUrl(website_url))
 
-    @qc.pyqtSlot()
+    @qc.Slot()
     def on_action_help(self):
         help_url = r"https://corrscope.github.io/corrscope/"
         QDesktopServices.openUrl(qc.QUrl(help_url))
@@ -711,7 +713,7 @@ class PreviewOrRender(Enum):
 class CorrThread(qc.QThread):
     is_aborted: Locked[bool]
 
-    @qc.pyqtSlot()
+    @qc.Slot()
     def abort(self):
         self.is_aborted.set(True)
 
@@ -722,8 +724,8 @@ class CorrThread(qc.QThread):
             for output in self.corr.outputs:
                 output.terminate(from_same_thread=False)
 
-    error = qc.pyqtSignal(str)
-    ffmpeg_missing = qc.pyqtSignal()
+    error = qc.Signal(str)
+    ffmpeg_missing = qc.Signal()
 
     def __init__(self, cfg: Config, arg: Arguments, mode: PreviewOrRender):
         qc.QThread.__init__(self)
@@ -772,7 +774,7 @@ class CorrProgressDialog(qw.QProgressDialog):
         # Close after CorrScope finishes.
         self.setAutoClose(True)
 
-    @qc.pyqtSlot(float, float)
+    @qc.Slot(float, float)
     def on_begin(self, begin_time, end_time):
         self.setRange(iround(begin_time), iround(end_time))
         # self.setValue is called by CorrScope, on the first frame.

--- a/corrscope/gui/history_file_dlg.py
+++ b/corrscope/gui/history_file_dlg.py
@@ -2,7 +2,7 @@ import os.path
 from pathlib import Path
 from typing import *
 
-import PyQt5.QtWidgets as qw
+import qtpy.QtWidgets as qw
 import attr
 
 import corrscope.settings.global_prefs as _gp

--- a/corrscope/gui/model_bind.py
+++ b/corrscope/gui/model_bind.py
@@ -278,7 +278,9 @@ class BoundDoubleSpinBox(qw.QDoubleSpinBox, BoundWidget):
     set_model = model_setter(float)
 
 
-CheckState = int
+# CheckState inherits from int on PyQt5 and Enum on PyQt6. To compare integers with
+# CheckState on both PyQt5 and 6, we have to call CheckState(int).
+CheckState = qc.Qt.CheckState
 
 
 class BoundCheckBox(qw.QCheckBox, BoundWidget):
@@ -290,12 +292,16 @@ class BoundCheckBox(qw.QCheckBox, BoundWidget):
     gui_changed = alias("stateChanged")
 
     # gui_changed -> set_model(Qt.CheckState).
-    @Slot(CheckState)
-    def set_model(self, value: CheckState):
-        """Qt.PartiallyChecked probably should not happen."""
-        Qt = qc.Qt
-        assert value in [Qt.Unchecked, Qt.PartiallyChecked, Qt.Checked]
-        self.set_bool(value != Qt.Unchecked)
+    @Slot(int)
+    def set_model(self, value: int):
+        """Qt.CheckState.PartiallyChecked probably should not happen."""
+        value = CheckState(value)
+        assert value in [
+            CheckState.Unchecked,
+            CheckState.PartiallyChecked,
+            CheckState.Checked,
+        ]
+        self.set_bool(value != CheckState.Unchecked)
 
     set_bool = model_setter(bool)
 
@@ -576,12 +582,16 @@ class _ColorCheckBox(qw.QCheckBox):
         with qc.QSignalBlocker(self):
             self.setChecked(bool(hex_color))
 
-    @Slot(CheckState)
-    def on_check(self, value: CheckState):
-        """Qt.PartiallyChecked probably should not happen."""
-        Qt = qc.Qt
-        assert value in [Qt.Unchecked, Qt.PartiallyChecked, Qt.Checked]
-        if value != Qt.Unchecked:
+    @Slot(int)
+    def on_check(self, value: int):
+        """Qt.CheckState.PartiallyChecked probably should not happen."""
+        value = CheckState(value)
+        assert value in [
+            CheckState.Unchecked,
+            CheckState.PartiallyChecked,
+            CheckState.Checked,
+        ]
+        if value != CheckState.Unchecked:
             self.color_text.setText("#ffffff")
         else:
             self.color_text.setText("")

--- a/corrscope/gui/model_bind.py
+++ b/corrscope/gui/model_bind.py
@@ -4,10 +4,10 @@ from collections import defaultdict
 from typing import *
 
 import attr
-from PyQt5 import QtWidgets as qw, QtCore as qc
-from PyQt5.QtCore import pyqtSlot
-from PyQt5.QtGui import QPalette, QColor, QFont
-from PyQt5.QtWidgets import QWidget
+from qtpy import QtWidgets as qw, QtCore as qc
+from qtpy.QtCore import pyqtSlot
+from qtpy.QtGui import QPalette, QColor, QFont
+from qtpy.QtWidgets import QWidget
 
 from corrscope.config import CorrError, DumpableAttrs, get_units
 from corrscope.gui.util import color2hex

--- a/corrscope/gui/util.py
+++ b/corrscope/gui/util.py
@@ -4,8 +4,8 @@ from operator import itemgetter
 from typing import TypeVar, Iterable, Generic, Tuple, Any, Optional
 
 import matplotlib.colors
-from PyQt5.QtCore import QMutex
-from PyQt5.QtWidgets import QErrorMessage, QWidget
+from qtpy.QtCore import QMutex
+from qtpy.QtWidgets import QErrorMessage, QWidget
 
 from corrscope.config import CorrError
 

--- a/corrscope/gui/util.py
+++ b/corrscope/gui/util.py
@@ -4,7 +4,7 @@ from operator import itemgetter
 from typing import TypeVar, Iterable, Generic, Tuple, Any, Optional
 
 import matplotlib.colors
-from qtpy.QtCore import QMutex
+from qtpy.QtCore import QMutex, QMutexLocker
 from qtpy.QtWidgets import QErrorMessage, QWidget
 
 from corrscope.config import CorrError
@@ -31,22 +31,17 @@ class Locked(Generic[T]):
     def __init__(self, obj: T):
         super().__init__()
         self.obj = obj
-        self.lock = QMutex(QMutex.Recursive)
-
-    def __enter__(self) -> T:
-        self.lock.lock()
-        return self.obj
-
-    def __exit__(self, *args) -> None:
-        self.lock.unlock()
+        self.lock = QMutex()
 
     def set(self, value: T) -> T:
-        with self:
+        # We don't actually need a mutex since Python holds the GIL during reads and
+        # writes. But keep it anyway.
+        with QMutexLocker(self.lock):
             self.obj = value
         return value
 
     def get(self) -> T:
-        with self:
+        with QMutexLocker(self.lock):
             return self.obj
 
 

--- a/corrscope/gui/version_common.py
+++ b/corrscope/gui/version_common.py
@@ -1,0 +1,4 @@
+import qtpy
+from packaging.version import parse
+
+QT6 = parse(qtpy.QT_VERSION) >= parse("6.0.0")

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from contextlib import contextmanager
 
-from PyQt5.QtCore import *
-from PyQt5.QtWidgets import *
+from qtpy.QtCore import *
+from qtpy.QtWidgets import *
 
 from corrscope.gui.view_stack import (
     LayoutStack,

--- a/corrscope/gui/view_stack.py
+++ b/corrscope/gui/view_stack.py
@@ -127,6 +127,12 @@ class LayoutStack:
 
 def set_layout(stack: LayoutStack, layout_type: Type[QLayout]) -> QLayout:
     layout = layout_type(stack.peek().widget)
+
+    # On macOS there is a different FieldGrowthPolicy used by default
+    # than on other OSes, therefore let's set a desired one here:
+    if layout_type == QFormLayout:
+        layout.setFieldGrowthPolicy(QFormLayout.FieldGrowthPolicy.ExpandingFieldsGrow)
+
     stack.peek().layout = layout
     return layout
 

--- a/corrscope/gui/view_stack.py
+++ b/corrscope/gui/view_stack.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 from typing import *
 
 import attr
-from PyQt5.QtCore import QObject, Qt
-from PyQt5.QtWidgets import *
+from qtpy.QtCore import QObject, Qt
+from qtpy.QtWidgets import *
 
 from corrscope.util import obj_name
 

--- a/corrscope/gui/widgets.py
+++ b/corrscope/gui/widgets.py
@@ -1,9 +1,9 @@
 from typing import TYPE_CHECKING, List, Callable
 
-from PyQt5 import QtWidgets as qw, QtCore as qc
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QKeySequence
-from PyQt5.QtWidgets import QShortcut
+from qtpy import QtWidgets as qw, QtCore as qc
+from qtpy.QtCore import Qt
+from qtpy.QtGui import QKeySequence
+from qtpy.QtWidgets import QShortcut
 
 from corrscope.gui.util import find_ranges
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -117,7 +117,7 @@ python-versions = "*"
 
 [[package]]
 name = "fonttools"
-version = "4.29.1"
+version = "4.30.0"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -355,7 +355,7 @@ name = "pyqt5"
 version = "5.15.6"
 description = "Python bindings for the Qt cross platform application toolkit"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -367,7 +367,7 @@ name = "pyqt5-qt5"
 version = "5.15.2"
 description = "The subset of a Qt installation needed by PyQt5."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -375,8 +375,36 @@ name = "pyqt5-sip"
 version = "12.9.1"
 description = "The sip module support for PyQt5"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
+
+[[package]]
+name = "pyqt6"
+version = "6.2.3"
+description = "Python bindings for the Qt cross platform application toolkit"
+category = "main"
+optional = true
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+PyQt6-Qt6 = ">=6.2.3"
+PyQt6-sip = ">=13.2,<14"
+
+[[package]]
+name = "pyqt6-qt6"
+version = "6.2.3"
+description = "The subset of a Qt installation needed by PyQt6."
+category = "main"
+optional = true
+python-versions = "*"
+
+[[package]]
+name = "pyqt6-sip"
+version = "13.2.1"
+description = "The sip module support for PyQt6"
+category = "main"
+optional = true
+python-versions = ">=3.6"
 
 [[package]]
 name = "pytest"
@@ -443,6 +471,20 @@ description = ""
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "qtpy"
+version = "2.0.1"
+description = "Provides an abstraction layer on top of the various Qt bindings (PyQt5/6 and PySide2/6)."
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+packaging = "*"
+
+[package.extras]
+test = ["pytest (>=6.0.0)", "pytest-cov (>=3.0.0)", "pytest-qt"]
 
 [[package]]
 name = "ruamel.yaml"
@@ -515,10 +557,14 @@ category = "dev"
 optional = false
 python-versions = ">=3.6"
 
+[extras]
+qt5 = ["PyQt5"]
+qt6 = ["PyQt6"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c20e1b2fc5ad3a807a2f8350ad57205992e5bb77424045262a1cebed87209923"
+content-hash = "9a23c59676ac8c63ed80c68f3b31b7d8a883221661882baf0b27446aeb82b2c7"
 
 [metadata.files]
 altgraph = [
@@ -587,8 +633,8 @@ delayed-assert = [
     {file = "delayed_assert-0.3.6.tar.gz", hash = "sha256:0e1c65afae4bae9c57b91c76e38287562924c9964a58c309249790c725c46239"},
 ]
 fonttools = [
-    {file = "fonttools-4.29.1-py3-none-any.whl", hash = "sha256:1933415e0fbdf068815cb1baaa1f159e17830215f7e8624e5731122761627557"},
-    {file = "fonttools-4.29.1.zip", hash = "sha256:2b18a172120e32128a80efee04cff487d5d140fe7d817deb648b2eee023a40e4"},
+    {file = "fonttools-4.30.0-py3-none-any.whl", hash = "sha256:6985cc5380c06db07fdc73ade15e6adbd4ce6ff850d7561ca00f97090b4b263d"},
+    {file = "fonttools-4.30.0.zip", hash = "sha256:084dd1762f083a1bf49e41da1bfeafb475c9dce46265690a6bdd33290b9a63f4"},
 ]
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
@@ -701,6 +747,7 @@ numpy = [
     {file = "numpy-1.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8251ed96f38b47b4295b1ae51631de7ffa8260b5b087808ef09a39a9d66c97ab"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:48a3aecd3b997bf452a2dedb11f4e79bc5bfd21a1d4cc760e703c31d57c84b3e"},
     {file = "numpy-1.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a3bae1a2ed00e90b3ba5f7bd0a7c7999b55d609e0c54ceb2b076a25e345fa9f4"},
+    {file = "numpy-1.22.3-cp310-cp310-win32.whl", hash = "sha256:f950f8845b480cffe522913d35567e29dd381b0dc7e4ce6a4a9f9156417d2430"},
     {file = "numpy-1.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:08d9b008d0156c70dc392bb3ab3abb6e7a711383c3247b410b39962263576cd4"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:201b4d0552831f7250a08d3b38de0d989d6f6e4658b709a02a73c524ccc6ffce"},
     {file = "numpy-1.22.3-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f8c1f39caad2c896bc0018f699882b345b2a63708008be29b1f355ebf6f933fe"},
@@ -834,6 +881,36 @@ pyqt5-sip = [
     {file = "PyQt5_sip-12.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:989d51c41456cc496cb96f0b341464932b957040d26561f0bb4cf5a0914d6b36"},
     {file = "PyQt5_sip-12.9.1.tar.gz", hash = "sha256:2f24f299b44c511c23796aafbbb581bfdebf78d0905657b7cee2141b4982030e"},
 ]
+pyqt6 = [
+    {file = "PyQt6-6.2.3-cp36-abi3-macosx_10_14_universal2.whl", hash = "sha256:577334c9d4518022a4cb6f9799dfbd1b996167eb31404b5a63d6c43d603e6418"},
+    {file = "PyQt6-6.2.3-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:8a2f357b86fec8598f52f16d5f93416931017ca1986d5f68679c9565bfc21fff"},
+    {file = "PyQt6-6.2.3-cp36-abi3-win_amd64.whl", hash = "sha256:11c039b07962b29246de2da0912f4f663786185fd74d48daac7a270a43c8d92a"},
+    {file = "PyQt6-6.2.3.tar.gz", hash = "sha256:a9bfcac198fe4b703706f809bb686c7cef5f60a7c802fc145c6b57929c7a6a34"},
+]
+pyqt6-qt6 = [
+    {file = "PyQt6_Qt6-6.2.3-py3-none-macosx_10_14_x86_64.whl", hash = "sha256:02c1f02c04cfac8affb66fc56cbf1d033fb36efee98dd40ba59e60c816018302"},
+    {file = "PyQt6_Qt6-6.2.3-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bdf799911f004f904b00b9424e590cdb9138e7fc687d036c73c458e4c6c2efbd"},
+    {file = "PyQt6_Qt6-6.2.3-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:7d6f37204714bf3a6686f4d32bddd8b13d7e1adec3039cd2d27901bb827d7610"},
+    {file = "PyQt6_Qt6-6.2.3-py3-none-win_amd64.whl", hash = "sha256:6c7fa27a71eb0da81f39ec7a8e2c298d5e2dfecbc923875dcc932478b3c50ef3"},
+]
+pyqt6-sip = [
+    {file = "PyQt6_sip-13.2.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:226e9e349aa16dc1132f106ca01fa99cf7cb8e59daee29304c2fea5fa33212ec"},
+    {file = "PyQt6_sip-13.2.1-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:0314d011633bc697e99f3f9897b484720e81a5f4ba0eaa5f05c5811e2e74ea53"},
+    {file = "PyQt6_sip-13.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:8b52d42e42e6e9f934ac7528cd154ac0210a532bb33fa1edfb4a8bbfb73ff88b"},
+    {file = "PyQt6_sip-13.2.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:e2e6a3972169891dbc33d806f50ebf17eaa47a487ff6e4910fe2485c47cb6c2b"},
+    {file = "PyQt6_sip-13.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a3d53fab72f959b45aeb954124255b585ff8d497a514a2582e0afd808fc2f3da"},
+    {file = "PyQt6_sip-13.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:082a80264699d4e2e919a7de8b6662886a353863d2b30a0047fe73d42e65c98e"},
+    {file = "PyQt6_sip-13.2.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c456d5ccc4478254052082e298db01bb9d0495471c1659046697bb5dc9d2506c"},
+    {file = "PyQt6_sip-13.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:65f5aee6195bd0e785bd74f75ee080a5d5fb840c03210956e4ccbdde481b487c"},
+    {file = "PyQt6_sip-13.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:43afd9c9fdbc5f6ed2e22cae0752a8b8d9545c6d85f314bd27b861e21d4a97fe"},
+    {file = "PyQt6_sip-13.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0a49f2d0bb49bc9d72665d62fb5ab6549c72dcf49e1e52dc2046edb8832a17a3"},
+    {file = "PyQt6_sip-13.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0ede42e84a79871022e1a8e4d5c05f70821b2795910c4cd103e863ce62bc8d68"},
+    {file = "PyQt6_sip-13.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:b0d92f4a21706b18ab80c088cded94cd64d32a0c48e1729a4cc53fe5ab93cc1a"},
+    {file = "PyQt6_sip-13.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:616b6bad827e9c6e7ce5179883ca0f44110a42dcb045344aa28a495c05e19795"},
+    {file = "PyQt6_sip-13.2.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f4226d4ab239d8655f94c42b397f23e6e85b246f614ff81162ef9321e47f7619"},
+    {file = "PyQt6_sip-13.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:4b119a8fd880ece15a5bdff583edccd89dbc79d49de2e11cbbd6bba72713d1f3"},
+    {file = "PyQt6_sip-13.2.1.tar.gz", hash = "sha256:b7bce59900b2e0a04f70246de2ccf79ee7933036b6b9183cf039b62eeae2b858"},
+]
 pytest = [
     {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
     {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
@@ -853,6 +930,10 @@ python-dateutil = [
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
+]
+qtpy = [
+    {file = "QtPy-2.0.1-py3-none-any.whl", hash = "sha256:d93f2c98e97387fcc9d623d509772af5b6c15ab9d8f9f4c5dfbad9a73ad34812"},
+    {file = "QtPy-2.0.1.tar.gz", hash = "sha256:adfd073ffbd2de81dc7aaa0b983499ef5c59c96adcfdcc9dea60d42ca885eb8f"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.17.21-py3-none-any.whl", hash = "sha256:742b35d3d665023981bd6d16b3d24248ce5df75fdb4e2924e93a05c1f8b61ca7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,16 @@ numpy = "^1.21"
 click = "^8.0.1"
 matplotlib = "^3.1"
 attrs = "^21.2.0"
-PyQt5 = "^5.15.4"
 appdirs = "^1.4.4"
 atomicwrites = "^1.4.0"
 colorspacious = "^1.1.2"
+QtPy = "^2.0.1"
+PyQt5 = {version = "^5.15", optional = true}
+PyQt6 = {version = "^6.2", optional = true}
+
+[tool.poetry.extras]
+qt5 = ["PyQt5"]
+qt6 = ["PyQt6"]
 
 [tool.poetry.dev-dependencies]
 pytest = "^7"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,4 +1,4 @@
-import PyQt5.QtWidgets as qw
+import qtpy.QtWidgets as qw
 
 from corrscope import gui
 from corrscope.corrscope import template_config


### PR DESCRIPTION
Using QtPy adds Mac M1 support. Note that this changes how corrscope is installed, requiring `corrscope[qt5]` or `poetry install -E qt5`. I'm not sure if you can *remove* the PyQt5 dependency when the qt6 extra is requested ([link](https://github.com/pypa/pip/issues/8686)), or enable the qt6 extra (or PyQt6) on M1 Mac by default.

Supersedes PyQt6 changes in #412 (but not other changes).

- [x] edit changelog
- [ ] Don't require `corrscope[qt5]`? https://github.com/pypa/pip/issues/8686, https://stackoverflow.com/questions/67476031/poetry-install-different-package-version-based-on-extras
- [x] fix QMutex/QRecursiveMutex on play
- [x] Replace Qt.Unchecked with Qt.CheckState.Unchecked
- [x] Fix CheckState usage

In PyQt5, `qtpy.QtCore.Qt.CheckState` inherits from `int`, compares equal to int, and any int can be casted to `CheckState`, and `CheckState` can be casted to int.

In PyQt6, `qtpy.QtCore.Qt.CheckState` instead inherits from `Enum`, does not compare equal to int, casting invalid int to `CheckState` raises `ValueError`, and `int(CheckState.Unchecked)` raises `TypeError`.

fuck it, just cast `CheckState(i)` and assume the input is valid.

See also:

- https://pypi.org/project/PyQtEnumConverter/
- https://riverbankcomputing.com/pipermail/pyqt/2020-December/043445.html lol calibre
- https://github.com/spyder-ide/qtpy/issues/233
- https://docs.python.org/3/library/enum.html

...

- [x] Play fails on Qt 5: "AttributeError: 'QRecursiveMutex' object has no attribute 'lock'"
- [x] Render fails on 5 and 6: "AttributeError: 'CorrThread' object has no attribute 'abort'"

```
Traceback (most recent call last):
  File "/home/nyanpasu64/code/corrscope/corrscope/gui/__init__.py", line 567, in on_action_render
    self.play_thread(outputs, PreviewOrRender.render, dlg)
  File "/home/nyanpasu64/code/corrscope/corrscope/gui/__init__.py", line 584, in play_thread
    dlg.canceled.connect(t.abort, Qt.DirectConnection)
AttributeError: 'CorrThread' object has no attribute 'abort'
```

- [x] Edit README to mention Mac Gatekeeper and M1 slowdown