### PR TITLE
Separate edge finding from slope-based correlation, add buffer resetting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,17 @@
 
 ### Major Changes
 
-- Rewrite the trigger algorithm to enhance determinism and reduce errors when DC offset varies within a frame (#403, #408)
-    - Triggering still makes mistakes, especially when DC offset varies within a frame (eg. NES 75% pulse changing volumes). This may be addressed in the future.
-    - Changed default triggering settings as well.
+- Rewrite the trigger algorithm to enhance determinism and reduce errors when DC offset varies within a frame (#403, #408, #416)
+    - Slope strength has been removed and folded into edge strength (#416). This should *usually* not reduce the ability to fine-tune triggering; if it does, let me know so I can reconsider this decision!
+    - Add control for DC removal rate (#408)
+    - Add control to reset buffer on new notes, when wave lines up poorly with buffer (#416)
+    - For more information, see help page ([link](https://corrscope.github.io/corrscope/)).
 
 ### Changelog
 
 - Fix passing absolute .wav paths into corrscope CLI (#398)
 - Fix preview error when clearing "Trigger/Render Width" table cells (#407)
-- Add control for DC removal rate (#408)
+- Reorganize GUI with edge triggering options before buffer (#416)
 
 ## 0.7.1
 

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -118,7 +118,9 @@ def template_config(**kwargs) -> Config:
         trigger_subsampling=1,
         render_subsampling=2,
         trigger=CorrelationTriggerConfig(
-            edge_strength=2,
+            mean_responsiveness=0.0,
+            edge_strength=1.0,
+            reset_below=0.3,
             responsiveness=0.5,
             pitch_tracking=SpectrumConfig(),
             # post_trigger=ZeroCrossingTriggerConfig(),

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -1118,6 +1118,7 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("trigger__sign_strength", float, None),
         Column("trigger__buffer_strength", float, None),
         Column("trigger__responsiveness", float, None, "Buffer\nResponsiveness"),
+        Column("trigger__reset_below", float, None, "Reset Below\nMatch"),
         Column("trigger__edge_direction", plus_minus_one, None),
         Column("trigger__edge_strength", float, None),
         Column("trigger__slope_strength", float, None),

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -1121,7 +1121,6 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("trigger__reset_below", float, None, "Reset Below\nMatch"),
         Column("trigger__edge_direction", plus_minus_one, None),
         Column("trigger__edge_strength", float, None),
-        Column("trigger__slope_strength", float, None),
         Column("trigger__slope_width", float, None),
     ]
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -1116,12 +1116,12 @@ class ChannelModel(qc.QAbstractTableModel):
         Column("render_width", int, 1, "Render Width ×", always_show=True),
         Column("trigger__mean_responsiveness", float, None, "DC Removal\nRate"),
         Column("trigger__sign_strength", float, None),
-        Column("trigger__buffer_strength", float, None),
-        Column("trigger__responsiveness", float, None, "Buffer\nResponsiveness"),
-        Column("trigger__reset_below", float, None, "Reset Below\nMatch"),
         Column("trigger__edge_direction", plus_minus_one, None),
         Column("trigger__edge_strength", float, None),
         Column("trigger__slope_width", float, None),
+        Column("trigger__buffer_strength", float, None),
+        Column("trigger__responsiveness", float, None, "Buffer\nResponsiveness"),
+        Column("trigger__reset_below", float, None, "Reset Below\nMatch"),
     ]
 
     idx_of_key = {}

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -335,6 +335,15 @@ class MainWindow(QWidget):
                     singleStep=0.1,
                 ):
                     pass
+                with add_row(
+                    s,
+                    tr("Reset Below Match"),
+                    BoundDoubleSpinBox,
+                    name="trigger__reset_below",
+                    maximum=1.0,
+                    singleStep=0.1,
+                ):
+                    pass
                 with add_row(s, BoundCheckBox, Both) as (self.trigger__pitch_tracking):
                     assert isinstance(self.trigger__pitch_tracking, QWidget)
 

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -366,14 +366,6 @@ class MainWindow(QWidget):
                     s.widget.setMinimum(0.0)
                 with add_row(
                     s,
-                    tr("Slope Strength\n(for PSG/C64/FM)"),
-                    BoundDoubleSpinBox,
-                    name="trigger__slope_strength",
-                ):
-                    s.widget.setSingleStep(10)
-                    s.widget.setMaximum(200)
-                with add_row(
-                    s,
                     tr("Slope Width"),
                     BoundDoubleSpinBox,
                     name="trigger__slope_width",

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -317,6 +317,33 @@ class MainWindow(QWidget):
                     pass
 
             with append_widget(
+                s, QGroupBox, title=tr("Edge Triggering"), layout=QFormLayout
+            ):
+                with add_row(
+                    s,
+                    tr("Trigger Direction"),
+                    BoundComboBox,
+                    name="trigger__edge_direction",
+                ):
+                    pass
+                with add_row(
+                    s,
+                    tr("Edge Strength"),
+                    BoundDoubleSpinBox,
+                    name="trigger__edge_strength",
+                ):
+                    s.widget.setMinimum(0.0)
+                with add_row(
+                    s,
+                    tr("Slope Width"),
+                    BoundDoubleSpinBox,
+                    name="trigger__slope_width",
+                ):
+                    s.widget.setMinimum(0)
+                    s.widget.setMaximum(2)
+                    s.widget.setSingleStep(0.02)
+
+            with append_widget(
                 s, QGroupBox, title=tr("Wave History Alignment"), layout=QFormLayout
             ):
                 with add_row(
@@ -346,33 +373,6 @@ class MainWindow(QWidget):
                     pass
                 with add_row(s, BoundCheckBox, Both) as (self.trigger__pitch_tracking):
                     assert isinstance(self.trigger__pitch_tracking, QWidget)
-
-            with append_widget(
-                s, QGroupBox, title=tr("Edge Triggering"), layout=QFormLayout
-            ):
-                with add_row(
-                    s,
-                    tr("Trigger Direction"),
-                    BoundComboBox,
-                    name="trigger__edge_direction",
-                ):
-                    pass
-                with add_row(
-                    s,
-                    tr("Edge Strength"),
-                    BoundDoubleSpinBox,
-                    name="trigger__edge_strength",
-                ):
-                    s.widget.setMinimum(0.0)
-                with add_row(
-                    s,
-                    tr("Slope Width"),
-                    BoundDoubleSpinBox,
-                    name="trigger__slope_width",
-                ):
-                    s.widget.setMinimum(0)
-                    s.widget.setMaximum(2)
-                    s.widget.setSingleStep(0.02)
 
             with append_widget(
                 s, QGroupBox, title=tr("Post Triggering"), layout=QFormLayout

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -376,7 +376,6 @@ class CorrelationTrigger(MainTrigger):
         return self.cfg.pitch_tracking
 
     def calc_buffer_std(self, period: float) -> float:
-        period = period or (self.A + self.B)
         return period * self.cfg.buffer_falloff
 
     def __init__(self, *args, **kwargs):
@@ -421,6 +420,7 @@ class CorrelationTrigger(MainTrigger):
         # noinspection PyTypeChecker
         slope_width: float = np.clip(cfg.slope_width * period, 1.0, self.A / 3)
 
+        buffer_std = self._prev_buffer_std or kernel_size
         # We want:
         #   abs_area(slope) / abs_area(buffer) = (E=edge_strength) / (B=B)
         #
@@ -436,7 +436,7 @@ class CorrelationTrigger(MainTrigger):
         #   (w(slope) * h(slope)) / E      = (w(buffer) * B) / B
         #   slope_width * h(slope) / E     = _prev_buffer_std
         #   h(slope)                       = E * _prev_buffer_std / slope_width
-        slope_strength = cfg.edge_strength * self._prev_buffer_std / slope_width
+        slope_strength = cfg.edge_strength * buffer_std / slope_width
         # slope_width is 1.0 or greater, so this doesn't divide by 0.
 
         slope_finder = np.empty(kernel_size, dtype=f32)  # type: np.ndarray[f32]

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -278,15 +278,16 @@ class CorrelationTriggerConfig(
     # Correlation detection
     buffer_strength: float = 1
 
-    # _update_buffer()
+    # _update_buffer() (not in GUI)
     buffer_falloff: float = 0.5
 
-    # Maximum distance to move (in terms of trigger_ms/trigger_samp)
+    # Maximum distance to move (in terms of trigger_ms/trigger_samp) (not in GUI)
     trigger_diameter: float = 0.5
 
-    # Maximum distance to move (in terms of estimated wave period)
+    # Maximum distance to move (in terms of estimated wave period) (not in GUI)
     trigger_radius_periods: Optional[float] = 1.5
 
+    # (not in GUI)
     recalc_semitones: float = 1.0
 
     # _update_buffer
@@ -295,7 +296,7 @@ class CorrelationTriggerConfig(
     # Period/frequency estimation (not in GUI)
     max_freq: float = with_units("Hz", default=4000)
 
-    # Pitch tracking = compute spectrum.
+    # Pitch tracking = compute spectrum. (GUI only has a checkbox)
     pitch_tracking: Optional[SpectrumConfig] = None
 
     # region Legacy Aliases

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -432,6 +432,7 @@ class CorrelationTrigger(MainTrigger):
         data_begin = trigger_begin - stride * self.A
 
         # Get subsampled data (1D, downmixed to mono)
+        # [data_nsubsmp = A + _trigger_diameter + B] Amplitude
         data = self._wave.get_padded(
             data_begin, data_begin + stride * data_nsubsmp, stride
         )
@@ -485,8 +486,18 @@ class CorrelationTrigger(MainTrigger):
             edge_score = None
 
         corr_enabled = bool(cfg.buffer_strength) and bool(cfg.responsiveness)
+
+        # Buffer sizes:
+        # data_nsubsmp = A + _trigger_diameter + B
+        kernel_size = self.A + self.B
+        corr_nsamp = self._trigger_diameter + 1
+        assert corr_nsamp == data_nsubsmp - kernel_size + 1
         # array[A+B] Amplitude
-        corr_kernel: np.ndarray = self._corr_buffer * cfg.buffer_strength
+        corr_kernel: np.ndarray = (
+            self._corr_buffer * cfg.buffer_strength
+            if corr_enabled
+            else np.zeros(kernel_size, f32)
+        )
         if slope_finder is not None:
             corr_kernel += slope_finder
 
@@ -517,7 +528,7 @@ class CorrelationTrigger(MainTrigger):
             """If radius is set, the returned offset is limited to ±radius from the
             center of correlation.
             """
-            assert len(corr) == len(peaks) == self._trigger_diameter + 1
+            assert len(corr) == len(peaks) == corr_nsamp
             # returns double, not single/f32
             begin_offset = 0
 
@@ -551,10 +562,9 @@ class CorrelationTrigger(MainTrigger):
 
         del data
 
-        Ntrigger = self.A + self.B
         if self.post:
-            new_data = self._wave.get_around(trigger, Ntrigger, stride)
-            cache.mean = np.add.reduce(new_data) / Ntrigger
+            new_data = self._wave.get_around(trigger, kernel_size, stride)
+            cache.mean = np.add.reduce(new_data) / kernel_size
 
             # Apply post trigger (before updating correlation buffer)
             trigger = self.post.get_trigger(trigger, cache)
@@ -563,9 +573,9 @@ class CorrelationTrigger(MainTrigger):
         self._prev_trigger = trigger = max(trigger, self._prev_trigger)
 
         # Update correlation buffer (distinct from visible area)
-        aligned = self._wave.get_around(trigger, Ntrigger, stride)
+        aligned = self._wave.get_around(trigger, kernel_size, stride)
         if cache.mean is None:
-            cache.mean = np.add.reduce(aligned) / Ntrigger
+            cache.mean = np.add.reduce(aligned) / kernel_size
         self._update_buffer(aligned, cache)
 
         self._frames_since_spectrum += 1

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -665,7 +665,7 @@ class CorrelationTrigger(MainTrigger):
             data -= cache.mean
             normalize_buffer(data)
             window = gaussian_or_zero(
-                N, std=(cache.period / self._stride) * buffer_falloff
+                N, std=(cache.period / self._stride or N) * buffer_falloff
             )
             data *= window
 

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -347,9 +347,6 @@ class CorrelationTrigger(MainTrigger):
     _corr_buffer: "npt.NDArray[f32]"
     """(mutable) [A+B] Amplitude"""
 
-    _edge_finder: "npt.NDArray[f32]"
-    """(const) [A+B] Amplitude"""
-
     _prev_mean: float
     _prev_period: Optional[int]
     _prev_slope_finder: "Optional[npt.NDArray[f32]]"

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -281,7 +281,7 @@ class CorrelationTriggerConfig(
     edge_strength: float
 
     # Slope detection
-    slope_width: float = with_units("period", default=0.07)
+    slope_width: float = with_units("period", default=0.25)
 
     # Correlation detection
     buffer_strength: float = 1

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -484,17 +484,25 @@ class CorrelationTrigger(MainTrigger):
         else:
             edge_score = None
 
+        corr_enabled = bool(cfg.buffer_strength) and bool(cfg.responsiveness)
         # array[A+B] Amplitude
         corr_kernel: np.ndarray = self._corr_buffer * cfg.buffer_strength
         if slope_finder is not None:
             corr_kernel += slope_finder
 
+        peak_kernel = self._corr_buffer
+
         # `corr[x]` = correlation of kernel placed at position `x` in data.
         # `corr_kernel` is not allowed to move past the boundaries of `data`.
         corr = signal.correlate_valid(data, corr_kernel)
 
+        peaks = (
+            signal.correlate_valid(data, peak_kernel)
+            if corr_enabled
+            else np.zeros_like(corr)
+        )
         if edge_score is not None:
-            corr += edge_score
+            peaks += edge_score
 
         # Don't pick peaks more than `period * trigger_radius_periods` away from the
         # center.
@@ -503,10 +511,13 @@ class CorrelationTrigger(MainTrigger):
         else:
             trigger_radius = None
 
-        def find_peak(corr: np.ndarray, radius: Optional[int]) -> int:
+        def find_peak(
+            corr: np.ndarray, peaks: np.ndarray, radius: Optional[int]
+        ) -> int:
             """If radius is set, the returned offset is limited to ±radius from the
             center of correlation.
             """
+            assert len(corr) == len(peaks) == self._trigger_diameter + 1
             # returns double, not single/f32
             begin_offset = 0
 
@@ -518,24 +529,24 @@ class CorrelationTrigger(MainTrigger):
                 right = min(mid + radius + 1, Ncorr)
 
                 corr = corr[left:right]
+                peaks = peaks[left:right]
                 begin_offset = left
 
-            min_val = np.min(corr)
+            min_corr = np.min(corr)
 
             # Only permit local maxima. This fixes triggering errors where the edge
             # of the allowed range has higher correlation than edges in-bounds,
             # but isn't a rising edge itself (a local maximum of alignment).
-            orig = corr.copy()
-            corr[:-1][orig[:-1] < orig[1:]] = min_val
-            corr[1:][orig[1:] < orig[:-1]] = min_val
-            corr[0] = corr[-1] = min_val
+            corr[:-1][peaks[:-1] < peaks[1:]] = min_corr
+            corr[1:][peaks[1:] < peaks[:-1]] = min_corr
+            corr[0] = corr[-1] = min_corr
 
             # Find optimal offset
             peak_offset = np.argmax(corr) + begin_offset  # type: int
             return peak_offset
 
         # Find correlation peak.
-        peak_offset = find_peak(corr, trigger_radius)
+        peak_offset = find_peak(corr, peaks, trigger_radius)
         trigger = trigger_begin + stride * (peak_offset)
 
         del data

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -36,15 +36,13 @@ def trigger_template(**kwargs) -> CorrelationTriggerConfig:
 @fixture
 @parametrize("trigger_diameter", [0.5, 1.0])
 @parametrize("pitch_tracking", [None, SpectrumConfig()])
-@parametrize("slope_strength", [0, 100])
 @parametrize("sign_strength", [0, 1])
 def trigger_cfg(
-    trigger_diameter, pitch_tracking, slope_strength, sign_strength
+    trigger_diameter, pitch_tracking, sign_strength
 ) -> CorrelationTriggerConfig:
     return trigger_template(
         trigger_diameter=trigger_diameter,
         pitch_tracking=pitch_tracking,
-        slope_strength=slope_strength,
         sign_strength=sign_strength,
         slope_width=0.14,
     )


### PR DESCRIPTION
TODO:

- [x] ~~fix default config (set slope to nonzero)~~ goodbye slope
- [x] ~~set slope step to 5 or so~~ goodbye slope
- [x] Don't make `calc_buffer_std()` use wide buffers upon period 0 (https://github.com/corrscope/corrscope/issues/404#issuecomment-1069557918)
	- it breaks all triggering somehow, in test_trigger and knuckles-seascape
	- The problem is that `slope_width` ~~is calculated based on the current period, while `slope_strength` is based off the previous~~ is multiplied by `_prev_buffer_std`.
	- **And `_prev_buffer_std` is never updated if buffering is disabled.**
		- [x] Replace `_prev_buffer_std=0` with N
		- [ ] Perhaps use the maximum of `calc_buffer_std(period)` and `_prev_buffer_std`?
- [x] Pick default slope width
- [x] fix docs
	- [x] document buffer resetting in the technical section
- [ ] code review
- [x] changelog

What default slope width should I use?

- Seascape: 0.30
- Extends Levant: 0.25 for PSG, 0.5 for bass
- Chrono: 0.15
- Emerald Hill Zone: 0.10, needs to be even lower to trigger weird reverse spiky waves

0.25 I suppose?

- [x] It is less than intuitive that slope strength (and jumping around) increases as slope width decreases.

Reverting this fixes "edge finding strength is too low and the slope evaluation strength is too high" ([link](https://github.com/corrscope/corrscope/issues/404#issuecomment-1069649154)), but is the result acceptable? Probably yes, if you care about narrow edge features, you want to increase edge strength. ...but now I have 3:1 edge/buffer and I'm *still* getting errors in Emerald Hill Zone... Should I multiply slope by 2?

**edge strength * 5.**

Deferred (see #419):

- [x] ~~mark old modules as incompatible and warn~~ no longer incompatible
- [x] ~~Does sine-shaped slope kernel work better or worse than split gaussian? (probably worse upon too-long period estimates)~~
