### PR TITLE
Use regular trigger's smoothed mean for post triggering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Major Changes
 
-- Rewrite the trigger algorithm to enhance determinism and reduce errors when DC offset varies within a frame (#403, #408, #416)
+- Rewrite the trigger algorithm to enhance determinism and reduce errors when DC offset varies within a frame (#403, #408, #416, #420)
     - Slope strength has been removed and folded into edge strength (#416). This should *usually* not reduce the ability to fine-tune triggering; if it does, let me know so I can reconsider this decision!
     - Add control for DC removal rate (#408)
     - Add control to reset buffer on new notes, when wave lines up poorly with buffer (#416)

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -233,7 +233,7 @@ def test_post_trigger_radius():
     cfg = ZeroCrossingTriggerConfig()
     post = cfg(wave, radius, 1, FPS)
 
-    cache = PerFrameCache(mean=0)
+    cache = PerFrameCache(smoothed_mean=0)
 
     for offset in range(-radius, radius + 1):
         assert post.get_trigger(center + offset, cache) == center, offset


### PR DESCRIPTION
This allows setting mean responsiveness to 0 to affect post triggering as well as regular (good), without introducing DC offset to the buffer (which would cause problems).

Additionally it causes the post trigger to use the same DC offset as the regular trigger, rather than the offset around the trigger point (which is debatable).

- [x] changelog

See  #419.