### PR TITLE
Exclude preview/render thread from App Nap throttling on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 0.8.1 (unreleased)
 
-No changes yet.
+### Changelog
+
+- Fix slowdown on (M1?) Macs around 40 seconds after preview/render starts (#428)
 
 ## 0.8.0
 

--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ poetry run corr (args)
 
 ## Mac-specific Issues
 
-### M1 Slowdown
-
-On M1 processors, if you open preview, after 40 or so seconds, the preview may suddenly slow down and audio will stop playing. This is because macOS thinks ffplay is the active app, and Corrscope is a background job burning CPU, so it moves Corrscope to an Efficiency core, slowing it down.
-
-There is no fix for this issue at the moment. As a workaround, you can click on Corrscope's window to avoid the slowdown, and drag it aside so it doesn't obstruct the preview.
-
 ### Gatekeeper
 
 On Mac, if you render a video file, in some cases (eg. IINA video player) you may not be able to open the resulting files. Gatekeeper will print an error saying '"filename.mp4" cannot be opened because it is from an unidentified developer.'. If you see this message, try opening the file again. Once you silence the error once, it should not reappear.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ poetry run corr (args)
 
 ## Mac-specific Issues
 
+### Preview audio cutting out
+
+When you preview a video in Corrscope, it sends video frames to ffplay, which opens a video player window and also plays synchronized audio. On Mac (at least my M1 MacBook Air running macOS 12.3), switching windows can cause ffplay to stutter and temporarily or semi-permanently stop playing audio (until you restart the preview). There is no fix for this issue at the moment.
+
+Rendering does not stutter on M1, since neither corrscope nor ffmpeg are affected by app switching, or App Nap.
+
 ### Gatekeeper
 
 On Mac, if you render a video file, in some cases (eg. IINA video player) you may not be able to open the resulting files. Gatekeeper will print an error saying '"filename.mp4" cannot be opened because it is from an unidentified developer.'. If you see this message, try opening the file again. Once you silence the error once, it should not reappear.

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from types import MethodType
 from typing import Optional, List, Any, Tuple, Callable, Union, Dict, Sequence, NewType
 
+import appnope
 import qtpy.QtCore as qc
 import qtpy.QtWidgets as qw
 import attr
@@ -743,21 +744,22 @@ class CorrJob(qc.QObject):
         """Called in separate thread."""
         cfg = self.cfg
         arg = self.arg
-        try:
-            self.corr = CorrScope(cfg, arg)
-            self.corr.play()
+        with appnope.nope_scope(reason="corrscope preview/render active"):
+            try:
+                self.corr = CorrScope(cfg, arg)
+                self.corr.play()
 
-        except paths.MissingFFmpegError:
-            arg.on_end()
-            self.ffmpeg_missing.emit()
+            except paths.MissingFFmpegError:
+                arg.on_end()
+                self.ffmpeg_missing.emit()
 
-        except Exception as e:
-            arg.on_end()
-            stack_trace = format_stack_trace(e)
-            self.error.emit(stack_trace)
+            except Exception as e:
+                arg.on_end()
+                stack_trace = format_stack_trace(e)
+                self.error.emit(stack_trace)
 
-        else:
-            arg.on_end()
+            else:
+                arg.on_end()
 
 
 class CorrThread(Thread):

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,6 +15,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "appnope"
+version = "0.1.3"
+description = "Disable App Nap on macOS >= 10.9"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -564,7 +572,7 @@ qt6 = ["PyQt6"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "9a23c59676ac8c63ed80c68f3b31b7d8a883221661882baf0b27446aeb82b2c7"
+content-hash = "ba8d40b361935a2f92d90c35f173026f9e6afa1e61fe05a526c3ce519e009c23"
 
 [metadata.files]
 altgraph = [
@@ -574,6 +582,10 @@ altgraph = [
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
     {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
+appnope = [
+    {file = "appnope-0.1.3-py2.py3-none-any.whl", hash = "sha256:265a455292d0bd8a72453494fa24df5a11eb18373a60c7c0430889f22548605e"},
+    {file = "appnope-0.1.3.tar.gz", hash = "sha256:02bd91c4de869fbb1e1c50aafc4098827a7a54ab2f39d9dcba6c9547ed920e24"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ colorspacious = "^1.1.2"
 QtPy = "^2.0.1"
 PyQt5 = {version = "^5.15", optional = true}
 PyQt6 = {version = "^6.2", optional = true}
+appnope = "^0.1.3"
 
 [tool.poetry.extras]
 qt5 = ["PyQt5"]


### PR DESCRIPTION
Fixes slowdown ~40 seconds after beginning preview.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
