### PR TITLE
Remove setuptools from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,7 @@
 # "No apps associated with package UNKNOWN or its dependencies."
 
 [build-system]
-# "setuptools" is required to make `pip install .` work, due to
-# https://github.com/python-poetry/poetry/issues/3153#issuecomment-727196619 .
-requires = ["setuptools", "poetry_core>=1.0.0"]
+requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]


### PR DESCRIPTION
https://github.com/python-poetry/poetry/issues/3153 has been closed, so is this still necessary? My motivation is to avoid including setuptools as a dependency for this package in [nixpkgs](https://github.com/NixOS/nixpkgs).

- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
