### PR TITLE
Fix crash with pitch tracking on low-sample-rate channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improve error messages for 24-bit WAV files (#443)
 - Add end time field to GUI (#451)
 - Change GUI render divisor to 4 decimal places (#451)
+-  Fix crash with pitch tracking on low-sample-rate channels (#453)
 
 ## 0.8.1
 

--- a/corrscope/spectrum.py
+++ b/corrscope/spectrum.py
@@ -156,9 +156,10 @@ def split(data: np.ndarray, fenceposts: Sequence[FFTIndex]) -> List[np.ndarray]:
     for i in range(len(fenceposts) - 1):
         st = fenceposts[i]
         end = fenceposts[i + 1]
-        if not st < ndata:
-            break
-        region = data[st:end]
+        if st < ndata:
+            region = data[st:end]
+        else:
+            region = np.zeros([1], data.dtype)
         sub_arys.append(region)
 
     return sub_arys


### PR DESCRIPTION
The bug generally occured when using a trigger width multiplier large enough that the highest FFT bin (half of sampling rate) is below the highest pitch tracking note (5120 Hz).

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
