### PR TITLE
Fix crash on macOS when closing window with preview active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Improve error messages for 24-bit WAV files (#443)
 - Add end time field to GUI (#451)
 - Change GUI render divisor to 4 decimal places (#451)
--  Fix crash with pitch tracking on low-sample-rate channels (#453)
+- Fix crash with pitch tracking on low-sample-rate channels (#453)
+- Fix crash on macOS when closing window with preview active (#454) 
 
 ## 0.8.1
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -307,7 +307,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             # But since the dialog is modal,
             # self.corr_thread cannot have been replaced by a different thread.
             if self.corr_thread is not None:
-                self.corr_thread.abort_terminate()
+                self.corr_thread.job.abort_terminate()
             return True
 
         return False


### PR DESCRIPTION
- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.

Seems to only segfault on Mac Qt6. Does not crash on Linux Qt5 and Windows Qt5/6, due to a coincidence.