### PR TITLE
Fix bug which would add correlation buffers to slope finder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 0.9.1 (unreleased)
 
+### Major Changes
+
+- Fix bug which would add correlation buffers to slope finder (#471, found by Tachometer)
+    - NOTE: This affects triggering behavior compared to older program versions.
+
 ## 0.9.0
 
 ### Features

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -438,7 +438,7 @@ class CorrelationTrigger(MainTrigger):
         slope_width: float = np.clip(cfg.slope_width * period, 1.0, self.A / 3)
 
         # This is a fudge factor. Adjust it until it feels right.
-        slope_strength = cfg.edge_strength * 5
+        slope_strength = cfg.edge_strength * 2
         # slope_width is 1.0 or greater, so this doesn't divide by 0.
 
         slope_finder = np.empty(kernel_size, dtype=f32)  # type: np.ndarray[f32]

--- a/corrscope/triggers.py
+++ b/corrscope/triggers.py
@@ -548,11 +548,12 @@ class CorrelationTrigger(MainTrigger):
         else:
             corr_quality = np.zeros(corr_nsamp, f32)
 
-        # array[A+B] Amplitude
-        corr_kernel = slope_finder
-        del slope_finder
         if corr_enabled:
-            corr_kernel += self._corr_buffer * cfg.buffer_strength
+            # array[A+B] Amplitude
+            # Don't mutate (self._prev_slope_finder = slope_finder).
+            corr_kernel = slope_finder + self._corr_buffer * cfg.buffer_strength
+        else:
+            corr_kernel = slope_finder
 
         # `corr[x]` = correlation of kernel placed at position `x` in data.
         # `corr_kernel` is not allowed to move past the boundaries of `data`.


### PR DESCRIPTION
The slope finder has a width based on the current note's period. It's normally recalculated whenever the period changes. But previously we were erroneously adding the current buffer to the cached slope finder on every frame, then reusing the cached slope finder on the next frame (adding the next frame's buffer again and so on), until the period changes and we reset the slope finder. This would hurt triggering accuracy of long evolving notes by comparing the latest wave to stale buffers.

This PR fixes the issue by writing the sum to a new buffer, avoiding corrupting the slope finder on each frame. This changes triggering results of existing configs and files. It should improve accuracy of long evolving notes, but may alter (degrade?) the accuracy of non-evolving notes by favoring high-slope points over buffer matches (where we'd previously add every previous buffer to the correlation kernel, drowning out the slope finder over the course of a note).

- [ ] Verify this doesn't hurt triggering accuracy on existing songs, requiring parameter changes
- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
