### PR TITLE
Fix stray triggering results in long areas of audio with no rising edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix bug which would add correlation buffers to slope finder (#471, found by Tachometer)
     - NOTE: This affects triggering behavior compared to older program versions.
+- Fix stray triggering results in long areas of audio with no rising edges (#474)
 
 ## 0.9.0
 


### PR DESCRIPTION
When `buffer_strength = 0` and no rising edges were in range (based on the estimated period), corrscope would erroneously return the leftmost point in its view (based on the estimated period). This would often result in triggering in the *middle* of a positive segment.

Instead return the center point. In NES oscilloscopes, this returns a value past the falling edge and in a near-silent region (which is more visually appealing).

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
