### PR TITLE
Switch default track orientation to horizontal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Add support for showing stereo balance as bars (#475)
 - Add external triggering (#476)
 
+### Major Changes
+
+- Switch default track orientation to horizontal (#477)
+
 ## 0.9.1
 
 ### Major Changes

--- a/corrscope/corrscope.py
+++ b/corrscope/corrscope.py
@@ -139,7 +139,7 @@ def template_config(**kwargs) -> Config:
         ),
         channels=[],
         default_label=DefaultLabel.FileName,
-        layout=LayoutConfig(orientation="v", stereo_orientation="v", ncols=0),
+        layout=LayoutConfig(orientation="h", stereo_orientation="v", ncols=0),
         render=RendererConfig(
             1920,
             1080,


### PR DESCRIPTION
This may make the resulting oscilloscope views less confusing (adjacent tracks are horizontally nearby rather than vertically).

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
