### PR TITLE
Add warning when rendering partial video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 
 - Switch default track orientation to horizontal (#477)
 
+### Changelog
+
+- Add warning when rendering partial video (#478)
+
 ## 0.9.1
 
 ### Major Changes

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -583,6 +583,19 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
             qw.QMessageBox.critical(self, "Error", error_msg)
             return
 
+        if self.cfg.begin_time or self.cfg.end_time:
+            Msg = qw.QMessageBox
+
+            title = self.tr("Render partial video")
+            message = self.tr(
+                "Are you sure you want to render a partial video?\n"
+                "(Begin/End Time is set.)"
+            )
+            response = Msg.question(self, title, message, Msg.Yes | Msg.No, Msg.Yes)
+
+            if response != Msg.Yes:
+                return
+
         # Name and extension (no folder).
         video_filename = self.get_save_filename(cli.VIDEO_NAME)
         filters = [


### PR DESCRIPTION
This prevents accidentally rendering part of a video when you expected to render and encode the full project.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
