### PR TITLE
Encode audio using libopus instead of aac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.11.0 (unreleased)
 
+### Major Changes
+
+- Encode audio using libopus instead of aac (#487)
+
 ## 0.10.1
 
 ### Changelog

--- a/corrscope/outputs.py
+++ b/corrscope/outputs.py
@@ -247,7 +247,7 @@ class FFmpegOutputConfig(IOutputConfig):
         "-color_range 1 -colorspace bt709 -color_trc bt709 -color_primaries bt709 "
         "-movflags faststart"
     )
-    audio_template: str = "-c:a aac -b:a 384k"
+    audio_template: str = "-c:a libopus -b:a 256k"
 
 
 FFMPEG = "ffmpeg"


### PR DESCRIPTION
opus in mp4 is supported by modern versions of ffmpeg, as well as YouTube upload. libopus is known to have good audio quality, while FFmpeg's built-in AAC encoder is slow and low-quality (especially on older ffmpeg versions)

- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
