### PR TITLE
Fix loss of volume when using a mono track as master audio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Major Changes
 
 - Encode audio using libopus instead of aac (#487)
+- Fix loss of volume when using a mono track as master audio (#488)
 
 ## 0.10.1
 


### PR DESCRIPTION
By default, when converting or playing mono audio tracks as stereo, ffmpeg halves the power of the left/right audio channels. This is undesirable since it makes mono tracks quieter than intended.

This commit makes corrscope detect mono master audio, and tell ffmpeg to play audio at full volume in both channels. We cannot enable this for stereo master audio, since it will discard the right input channel.

- Confirmed that command line is unaltered for stereo master audio, altered for mono, and volume matches between VLC master audio and Corrscope preview (using Audacity Windows loopback audio capture).

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
