### PR TITLE
Add "Reload Font List" menu item to fix missing fonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - Implement split stereo bar colors (#491)
+- Add "Reload Font List" menu item to fix missing fonts (#492)
 
 ### Major Changes
 

--- a/corrscope/gui/__init__.py
+++ b/corrscope/gui/__init__.py
@@ -11,6 +11,7 @@ from types import MethodType
 from typing import Optional, List, Any, Tuple, Callable, Union, Dict, Sequence, NewType
 
 import appnope
+import matplotlib as mpl
 import qtpy.QtCore as qc
 import qtpy.QtWidgets as qw
 import attr
@@ -215,6 +216,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
         self.action_parallel.setChecked(self.pref.parallel)
         self.action_parallel.toggled.connect(self.on_parallel_toggled)
 
+        self.action_clear_font_cache.triggered.connect(self.on_clear_font_cache)
         self.action_open_config_dir.triggered.connect(self.on_open_config_dir)
 
         self.actionNew.triggered.connect(self.on_action_new)
@@ -448,6 +450,7 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
     action_separate_render_dir: qw.QAction
     action_open_config_dir: qw.QAction
+    action_clear_font_cache: qw.QAction
 
     # Loading mainwindow.ui changes menuBar from a getter to an attribute.
     menuBar: qw.QMenuBar
@@ -486,6 +489,16 @@ class MainWindow(qw.QMainWindow, Ui_MainWindow):
 
     def on_parallel_toggled(self, checked: bool):
         self.pref.parallel = checked
+
+    def on_clear_font_cache(self):
+        # On Windows, matplotlibrc (if present) and font cache share a folder:
+        # https://matplotlib.org/stable/install/index.html#matplotlib-configuration-and-cache-directory-locations
+        # Only delete font cache files, in case user has a custom RC.
+        # TODO test matplotlib with custom RC?
+
+        mpl_cache = mpl.get_cachedir()
+        for file in Path(mpl_cache).glob("fontlist-*.json"):
+            file.unlink()
 
     def on_open_config_dir(self):
         appdata_uri = qc.QUrl.fromLocalFile(str(paths.appdata_dir))

--- a/corrscope/gui/view_mainwindow.py
+++ b/corrscope/gui/view_mainwindow.py
@@ -311,7 +311,7 @@ class MainWindow(QWidget):
     def add_trigger_tab(self, s: LayoutStack) -> QWidget:
         tr = self.tr
 
-        with self.add_tab_stretch(s, tr("&Trigger"), layout=QVBoxLayout) as tab:
+        with self.add_tab_stretch(s, tr("T&rigger"), layout=QVBoxLayout) as tab:
             with append_widget(
                 s, QGroupBox, title=tr("Input Data Preprocessing"), layout=QFormLayout
             ):
@@ -509,6 +509,11 @@ class MainWindow(QWidget):
         self.action_parallel = create_element(
             QAction, MainWindow, text=tr("&Multi-Core Rendering"), checkable=True
         )
+        self.action_clear_font_cache = create_element(
+            QAction,
+            MainWindow,
+            text=tr("&Reload Font List"),
+        )
         self.action_open_config_dir = create_element(
             QAction, MainWindow, text=tr("Open &Config Folder")
         )
@@ -533,6 +538,7 @@ class MainWindow(QWidget):
                 w.addAction(self.action_separate_render_dir)
                 w.addAction(self.action_parallel)
                 w.addSeparator()
+                w.addAction(self.action_clear_font_cache)
                 w.addAction(self.action_open_config_dir)
 
             with append_menu(s, title=tr("&Help")) as self.menuHelp:


### PR DESCRIPTION
Matplotlib stores a cache of installed fonts, and does not reload it
when the user installs a new font and tries to use it. We workaround
this by adding a menu item which clears the font cache
(causing Matplotlib to reload its font list). This is easier than
telling users to find and delete a folder on their system.

Also change Trigger tab accelerator so users can use Alt+T to access
Tools -> Reload Font List.

- [x] do you think a menu item for "Reload Font List" will be more user-friendly than "Clear Font Cache"?
- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
