### PR TITLE
Unify writing config files (atomically) and global preferences (in UTF-8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 ### Changelog
 
 - When opening missing file via CLI, show dialog rather than crashing (#499)
+- Fix saving global settings after opening config in Unicode folder (#507)
+- Save config files atomically (#507)
 
 ## 0.10.1
 

--- a/corrscope/settings/global_prefs.py
+++ b/corrscope/settings/global_prefs.py
@@ -75,5 +75,5 @@ def load_prefs() -> GlobalPrefs:
 
 
 def dump_prefs(pref: GlobalPrefs) -> None:
-    with atomic_write(_PREF_PATH, overwrite=True) as f:
+    with atomic_write(_PREF_PATH, overwrite=True, encoding="utf-8") as f:
         yaml.dump(pref, f)

--- a/corrscope/settings/global_prefs.py
+++ b/corrscope/settings/global_prefs.py
@@ -1,8 +1,6 @@
 from typing import *
 
 import attr
-from atomicwrites import atomic_write
-
 from corrscope.config import DumpableAttrs, yaml
 from corrscope.settings import paths
 
@@ -75,5 +73,4 @@ def load_prefs() -> GlobalPrefs:
 
 
 def dump_prefs(pref: GlobalPrefs) -> None:
-    with atomic_write(_PREF_PATH, overwrite=True, encoding="utf-8") as f:
-        yaml.dump(pref, f)
+    yaml.dump(pref, _PREF_PATH)


### PR DESCRIPTION
- Fix saving global settings after opening config in Unicode folder
- Save config files atomically
  - Fixes #506.

In PR #377 (save GlobalPrefs atomically), I created a new codepath by passing a file into `yaml.dump`. Unfortunately I forgot to mark it as UTF-8 (regressing #311). This breaks saving settings after opening a config in a Unicode folder.

To prevent this from recurring, I restructured the code to always pass a Path into `yaml.dump()`, and write the file atomically.

- [x] Do all calls to `yaml.load()` pass in a Path so it loads in UTF-8?
- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
