### PR TITLE
Fix bug where previewing project files breaks them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Encode audio using libopus instead of aac (#487)
 - Fix loss of volume when using a mono track as master audio (#488)
+- Fix bug where previewing project files breaks them (#509)
 
 ### Changelog
 

--- a/corrscope/config.py
+++ b/corrscope/config.py
@@ -352,28 +352,17 @@ class DumpableAttrs:
         return state
 
     # SafeConstructor.construct_yaml_object() uses __setstate__ to load objects.
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: dict[str, Any]) -> None:
         """Apparently pickle.load() calls this method too?
         I have not evaluated whether this causes problems."""
 
-        other = self.new_from_state(state)
-
-        # You're... not supposed to? create two objects sharing the same __dict__.
-        # self.__dict__ is empty (because __setstate__() is called instead of __init__()),
-        # which violates this object's contract. So steal __dict__ from the other object.
-        #
-        # If we leave it in `other` as well, we will find self.__dict__ blanked
-        # when other.__del__() is called at a random point in the future (#504).
-        # So replace `other.__dict__`. (We could swap with self.__dict__, but the syntax
-        # is jankier in Python than Rust since Python lacks &mut.)
-        self.__dict__ = other.__dict__
-        other.__dict__ = {}
+        # https://stackoverflow.com/q/23461479 "Technically it is OK".
+        self.__init__(**self.prepare_state(state))
 
     # If called via instance, cls == type(self).
     @classmethod
-    def new_from_state(cls: Type[T], state: Dict[str, Any]) -> T:
-        """Redirect `Alias(key)=value` to `key=value`.
-        Then call the dataclass constructor (to validate parameters)."""
+    def prepare_state(cls: Type[T], state: dict[str, Any]) -> dict[str, Any]:
+        """Redirect `Alias(key)=value` to `key=value`."""
 
         cls_name = cls.__name__
         fields = attr.fields_dict(cls)
@@ -406,14 +395,15 @@ class DumpableAttrs:
                 new_state[key] = value
 
         del state
-        return cls(**new_state)
+        return new_state
 
 
 def evolve_compat(obj: DumpableAttrs, **changes):
     """Evolve an object, based on user-specified dict,
     while ignoring unrecognized keywords."""
     # In dictionaries, later values will always override earlier ones
-    return obj.new_from_state({**obj.__dict__, **changes})
+    new_state = obj.prepare_state({**obj.__dict__, **changes})
+    return type(obj)(**new_state)
 
 
 class KeywordAttrs(DumpableAttrs):


### PR DESCRIPTION
My code uses the `__setstate__` method to load config objects from YAML files. This method is also called by `pickle.load`. I deserialized data from YAML by passing the map into `new_from_state()` (creating a temporary object), then replacing `__dict__` with the temporary object's.

In some Python and library configurations (eg. 3.13 on Linux), when the temporary object is garbage-collected (and `__del__()` is called if present), its `__dict__` is blanked out. This also blanks out the `__dict__` of the config object at a random time, causing random crashes trying to access fields that should be present.

To fix this bug:

- The first commit replaces the other object's `__dict__` so blanking it doesn't affect the returned object.
- The second commit makes `__setstate__()` call `__init__(**state)` on the existing object, rather than constructing a second object from the class and stealing its `__dict__`.

Fixes #504.

- [x] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
