### PR TITLE
pyproject.toml: change `~` to `>` in `requires-python`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "corrscope"
 version = "0.11.1-pre"
 description = "Python program to render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm"
 authors = [{ name = "nyanpasu64", email = "nyanpasu64@tuta.io" }]
-requires-python = "~=3.10"
+requires-python = ">=3.10"
 readme = "README.md"
 license = "BSD-2-Clause"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "corrscope"
 version = "0.11.1-pre"
 description = "Python program to render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm"
 authors = [{ name = "nyanpasu64", email = "nyanpasu64@tuta.io" }]
-requires-python = ">=3.10"
+requires-python = "~=3.10.0"
 readme = "README.md"
 license = "BSD-2-Clause"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "corrscope"
 version = "0.11.1-pre"
 description = "Python program to render wave files into oscilloscope views, featuring advanced correlation-based triggering algorithm"
 authors = [{ name = "nyanpasu64", email = "nyanpasu64@tuta.io" }]
-requires-python = "~=3.10.0"
+requires-python = ">=3.10, <4"
 readme = "README.md"
 license = "BSD-2-Clause"
 


### PR DESCRIPTION
so that uv doesn't complain when building/running the program, where it'd say:
```
warning: The `requires-python` specifier (`~=3.10`) in `corrscope` uses the tilde specifier (`~=`)
without a patch version. This will be interpreted as `>=3.10, <4`. Did you mean `~=3.10.0` to
constrain the version as `>=3.10.0, <3.11`? We recommend only using the tilde specifier with a patch
version to avoid ambiguity.
```
as i'm running Python 3.14 and the program remains working just fine, the above suggestion really wasn't necessary

- [ ] If you are a maintainer (only @nyanpasu64 at the moment), make sure to edit the [changelog](CHANGELOG.md) if needed. Otherwise, a maintainer will edit the changelog.
